### PR TITLE
release: v2.0.0 — EMV/NFC overhaul, clean architecture, security hard…

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ master, main, develop ]
 
+# Cancel in-progress runs for the same branch/PR so stale runs don't waste minutes
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build & Test
@@ -25,21 +30,32 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Cache Gradle packages
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
       - name: Run Lint
         run: ./gradlew lint
 
       - name: Run Unit Tests
         run: ./gradlew testDebugUnitTest
+
+      - name: Upload Test Results (JUnit XML)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-xml
+          path: app/build/test-results/**/*.xml
+
+      - name: Upload Test Reports (HTML)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports-html
+          path: app/build/reports/tests/
+
+      - name: Upload Lint Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-results
+          path: app/build/reports/lint-results-debug.html
 
       - name: Build Debug APK
         run: ./gradlew assembleDebug
@@ -50,22 +66,8 @@ jobs:
           name: debug-apk
           path: app/build/outputs/apk/debug/*.apk
 
-      - name: Upload Test Results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results
-          path: app/build/reports/tests/
-
-      - name: Upload Lint Results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: lint-results
-          path: app/build/reports/lint-results-debug.html
-
   release:
-    name: Build Release APK
+    name: Build & Sign Release APK
     runs-on: ubuntu-latest
     needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
@@ -84,8 +86,31 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Decode keystore
+        run: |
+          umask 077
+          echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > keystore.jks
+
       - name: Build Release APK
+        env:
+          KEYSTORE_FILE: ${{ github.workspace }}/keystore.jks
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: ./gradlew assembleRelease
+
+      - name: Verify APK signature
+        run: |
+          APK=$(find app/build/outputs/apk/release -name "*.apk" | head -1)
+          if [ -z "$APK" ]; then
+            echo "No release APK found"
+            exit 1
+          fi
+          $ANDROID_HOME/build-tools/$(ls $ANDROID_HOME/build-tools | sort -V | tail -1)/apksigner verify --verbose "$APK"
+
+      - name: Delete keystore
+        if: always()
+        run: rm -f keystore.jks
 
       - name: Upload Release APK
         uses: actions/upload-artifact@v4

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
-    id("com.google.devtools.ksp") version "1.9.0-1.0.13"
-    id("dagger.hilt.android.plugin")
+    alias(libs.plugins.hilt.android)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -13,17 +13,25 @@ android {
         applicationId = "io.github.romantsisyk.nfccardreader"
         minSdk = 24
         targetSdk = 35
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 2
+        versionName = "2.0.0"
 
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner = "dagger.hilt.android.testing.HiltTestRunner"
         vectorDrawables {
             useSupportLibrary = true
         }
 
-        // Room schema export
         ksp {
             arg("room.schemaLocation", "$projectDir/schemas")
+        }
+    }
+
+    signingConfigs {
+        create("release") {
+            storeFile = System.getenv("KEYSTORE_FILE")?.let { file(it) }
+            storePassword = System.getenv("KEYSTORE_PASSWORD")
+            keyAlias = System.getenv("KEY_ALIAS")
+            keyPassword = System.getenv("KEY_PASSWORD")
         }
     }
 
@@ -35,38 +43,33 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            signingConfig = signingConfigs.getByName("release")
         }
     }
+
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-        
-        // Add this for record desugaring
-        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "17"
     }
     buildFeatures {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.1"
+        kotlinCompilerExtensionVersion = "1.5.14"
     }
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
-            // Fix for duplicate META-INF files
             excludes += "META-INF/gradle/incremental.annotation.processors"
         }
     }
-    // Enable test options
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
             isReturnDefaultValues = true
-            
-            // Add VM args for Mockito with Java 21
             all {
                 it.jvmArgs("-Dnet.bytebuddy.experimental=true")
             }
@@ -75,11 +78,9 @@ android {
 }
 
 dependencies {
-    // Add this for record desugaring
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.3")
-
     implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)  // Changed from implementation to ksp
+    ksp(libs.hilt.compiler)
+    ksp(libs.androidx.hilt.compiler)
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
@@ -89,54 +90,38 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
-
-    // Adding Material Icons Extended for additional icons
     implementation(libs.androidx.material.icons.extended)
 
-    // Room database
     implementation(libs.room.runtime)
     implementation(libs.room.ktx)
     ksp(libs.room.compiler)
 
-    // Navigation Compose
     implementation(libs.navigation.compose)
     implementation(libs.hilt.navigation.compose)
-    
-    // Base testing dependencies
-    testImplementation(libs.junit)
-    
-    // Mockito for mocking - using older versions known to be stable
-    testImplementation("org.mockito:mockito-core:3.12.4")
-    testImplementation("org.mockito:mockito-inline:3.12.4") 
-    
-    // Coroutines testing
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4")
-    
-    // AndroidX test dependencies
-    testImplementation("androidx.test:core:1.5.0")
-    testImplementation("androidx.test:runner:1.5.0")
-    testImplementation("androidx.arch.core:core-testing:2.2.0") // For InstantTaskExecutorRule
-    
-    // Robolectric for Android framework simulation in unit tests
-    testImplementation("org.robolectric:robolectric:4.9")
-    
-    // Hilt testing
-    testImplementation("com.google.dagger:hilt-android-testing:${libs.versions.hiltAndroid.get()}")
-    kspTest("com.google.dagger:hilt-android-compiler:${libs.versions.hiltAndroid.get()}")
 
-    // Fix for Android instrumented tests
+    // Unit tests
+    testImplementation(libs.junit)
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.mockito.inline)
+    testImplementation(libs.mockito.kotlin)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.androidx.test.core)
+    testImplementation(libs.androidx.test.runner)
+    testImplementation(libs.androidx.arch.core.testing)
+    testImplementation(libs.robolectric)
+    testImplementation(libs.hilt.android.testing)
+    kspTest(libs.hilt.compiler)
+
+    // Android instrumented tests
     androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation("androidx.test:runner:1.5.2")
-    androidTestImplementation("androidx.test:rules:1.5.0")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
-    androidTestImplementation("junit:junit:4.13.2")
-    androidTestImplementation("androidx.test.ext:junit:1.1.5")
-    androidTestImplementation("androidx.test.ext:junit-ktx:1.1.5")
-    
-    // Hilt testing for Android tests
-    androidTestImplementation("com.google.dagger:hilt-android-testing:${libs.versions.hiltAndroid.get()}")
-    kspAndroidTest("com.google.dagger:hilt-android-compiler:${libs.versions.hiltAndroid.get()}")
-    
+    androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation(libs.androidx.test.runner)
+    androidTestImplementation(libs.androidx.test.rules)
+    androidTestImplementation(platform(libs.androidx.compose.bom))
+    androidTestImplementation(libs.androidx.ui.test.junit4)
+    androidTestImplementation(libs.hilt.android.testing)
+    kspAndroidTest(libs.hilt.compiler)
+
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
 }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -124,6 +124,19 @@
     public static int wtf(...);
 }
 
+# Strip Throwable.printStackTrace (could dump card data via exception messages)
+-assumenosideeffects class java.lang.Throwable {
+    public void printStackTrace();
+}
+
+# Strip System.out / System.err writes that may have slipped in
+-assumenosideeffects class java.io.PrintStream {
+    public void println(%);
+    public void println(**);
+    public void print(%);
+    public void print(**);
+}
+
 # ============================================
 # NFC Classes - Keep for Android system
 # ============================================

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -33,13 +33,31 @@
 # ============================================
 # Room Database
 # ============================================
--keep class * extends androidx.room.RoomDatabase
--keep @androidx.room.Entity class *
+-keep class * extends androidx.room.RoomDatabase { *; }
+-keep @androidx.room.Entity class * { *; }
 -dontwarn androidx.room.paging.**
+
+# Keep Room-generated _Impl classes — R8 will strip these without explicit keep rules
+# because they are referenced only by reflection at runtime.
+-keep class **_Impl { *; }
+-keep class **_Impl$* { *; }
+
+# Keep DAO interfaces and their implementations
+-keep @androidx.room.Dao interface * { *; }
+-keep @androidx.room.Dao class * { *; }
+
+# Keep TypeConverter methods so Room can call them via reflection
+-keepclassmembers class * {
+    @androidx.room.TypeConverter <methods>;
+}
+
+# Keep Room migration classes
+-keep class * extends androidx.room.migration.Migration { *; }
 
 # Keep Room entity fields
 -keepclassmembers class io.github.romantsisyk.nfccardreader.data.local.entity.** {
     <fields>;
+    <init>(...);
 }
 
 # ============================================
@@ -101,6 +119,9 @@
     public static int v(...);
     public static int d(...);
     public static int i(...);
+    public static int w(...);
+    public static int e(...);
+    public static int wtf(...);
 }
 
 # ============================================

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,12 +8,16 @@
     <application
         android:name=".app.NFCReaderApplication"
         android:allowBackup="false"
+        android:fullBackupContent="@xml/backup_rules"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:hasFragileUserData="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.NFCCardReader">
+        android:theme="@style/Theme.NFCCardReader"
+        tools:targetApi="31">
 
         <activity
             android:name=".app.MainActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,12 +5,12 @@
     <uses-permission android:name="android.permission.NFC" />
     <uses-feature android:name="android.hardware.nfc" android:required="true" />
 
-    <uses-permission android:name="android.permission.VIBRATE" />
     <application
         android:name=".app.NFCReaderApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.NFCCardReader">
@@ -22,14 +22,12 @@
             android:theme="@style/Theme.NFCCardReader">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.nfc.action.TAG_DISCOVERED" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
-
         </activity>
     </application>
 

--- a/app/src/main/java/io/github/romantsisyk/nfccardreader/app/MainActivity.kt
+++ b/app/src/main/java/io/github/romantsisyk/nfccardreader/app/MainActivity.kt
@@ -42,10 +42,13 @@ class MainActivity : ComponentActivity() {
         window.setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE)
 
         nfcAdapter = NfcAdapter.getDefaultAdapter(this)
+        // Use FLAG_IMMUTABLE: NFC foreground dispatch delivers tag data via onNewIntent(),
+        // not by mutating the wrapped Intent. FLAG_MUTABLE is unnecessary and weakens
+        // PendingIntent integrity (Android 12+ best practice; CWE-927).
         nfcPendingIntent = PendingIntent.getActivity(
             this, 0,
             Intent(this, javaClass).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP),
-            PendingIntent.FLAG_MUTABLE
+            PendingIntent.FLAG_IMMUTABLE
         )
 
         setContent {
@@ -82,6 +85,13 @@ class MainActivity : ComponentActivity() {
     private fun handleNfcIntent() {
         val currentIntent = intent ?: return
         if (currentIntent.action in NFC_ACTIONS) {
+            // TODO(security): the manifest exports MainActivity with an
+            //  ACTION_TAG_DISCOVERED intent-filter, which means any app can
+            //  start the Activity with a forged Intent carrying a fabricated
+            //  EXTRA_TAG. The downstream parsing use-case must defensively
+            //  validate the Tag/Ndef extras before processing. Consider
+            //  also gating handleNfcIntent on Intent.getPackage()==null and
+            //  verifying the calling UID via referrer where feasible.
             viewModel.processNfcIntent(currentIntent)
             // Consume the intent so onResume doesn't re-fire it on next foreground
             setIntent(Intent())

--- a/app/src/main/java/io/github/romantsisyk/nfccardreader/app/MainActivity.kt
+++ b/app/src/main/java/io/github/romantsisyk/nfccardreader/app/MainActivity.kt
@@ -1,8 +1,11 @@
 package io.github.romantsisyk.nfccardreader.app
 
+import android.app.PendingIntent
+import android.content.Intent
+import android.content.IntentFilter
 import android.nfc.NfcAdapter
 import android.os.Bundle
-import android.util.Log
+import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -11,38 +14,47 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
-import androidx.lifecycle.lifecycleScope
 import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
 import io.github.romantsisyk.nfccardreader.presentation.navigation.NfcNavGraph
 import io.github.romantsisyk.nfccardreader.presentation.ui.theme.NFCCardReaderTheme
 import io.github.romantsisyk.nfccardreader.presentation.viewmodel.NFCReaderViewModel
-import kotlinx.coroutines.launch
 
-/**
- * Main activity for the NFC Card Reader application.
- *
- * Handles NFC intent discovery and hosts the navigation graph.
- */
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
+    // Used only for NFC lifecycle callbacks — UI state flows from hiltViewModel() in NavGraph.
     private val viewModel: NFCReaderViewModel by viewModels()
+
+    private var nfcAdapter: NfcAdapter? = null
+    private lateinit var nfcPendingIntent: PendingIntent
+    private val nfcIntentFilters = arrayOf(
+        IntentFilter(NfcAdapter.ACTION_TAG_DISCOVERED),
+        IntentFilter(NfcAdapter.ACTION_TECH_DISCOVERED),
+        IntentFilter(NfcAdapter.ACTION_NDEF_DISCOVERED)
+    )
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
+        // Prevent screenshots/screen-capture of card data
+        window.setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE)
+
+        nfcAdapter = NfcAdapter.getDefaultAdapter(this)
+        nfcPendingIntent = PendingIntent.getActivity(
+            this, 0,
+            Intent(this, javaClass).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP),
+            PendingIntent.FLAG_MUTABLE
+        )
+
         setContent {
             NFCCardReaderTheme {
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    val navController = rememberNavController()
-                    NfcNavGraph(
-                        navController = navController,
-                        viewModel = viewModel
-                    )
+                    NfcNavGraph(navController = rememberNavController())
                 }
             }
         }
@@ -51,30 +63,36 @@ class MainActivity : ComponentActivity() {
     override fun onResume() {
         super.onResume()
         viewModel.checkNfcAvailability()
+        // Enable foreground dispatch so taps go to onNewIntent, not a new Activity instance
+        nfcAdapter?.enableForegroundDispatch(this, nfcPendingIntent, nfcIntentFilters, null)
         handleNfcIntent()
     }
 
-    override fun onNewIntent(intent: android.content.Intent) {
+    override fun onPause() {
+        super.onPause()
+        nfcAdapter?.disableForegroundDispatch(this)
+    }
+
+    override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
         handleNfcIntent()
     }
 
     private fun handleNfcIntent() {
-        intent?.let {
-            Log.d("MainActivity", "Intent action: ${it.action}")
-            if (it.action == NfcAdapter.ACTION_TAG_DISCOVERED ||
-                it.action == NfcAdapter.ACTION_TECH_DISCOVERED ||
-                it.action == NfcAdapter.ACTION_NDEF_DISCOVERED
-            ) {
-                lifecycleScope.launch {
-                    try {
-                        viewModel.processNfcIntent(it)
-                    } catch (e: Exception) {
-                        Log.e("MainActivity", "Error processing NFC intent", e)
-                    }
-                }
-            }
+        val currentIntent = intent ?: return
+        if (currentIntent.action in NFC_ACTIONS) {
+            viewModel.processNfcIntent(currentIntent)
+            // Consume the intent so onResume doesn't re-fire it on next foreground
+            setIntent(Intent())
         }
+    }
+
+    companion object {
+        private val NFC_ACTIONS = setOf(
+            NfcAdapter.ACTION_TAG_DISCOVERED,
+            NfcAdapter.ACTION_TECH_DISCOVERED,
+            NfcAdapter.ACTION_NDEF_DISCOVERED
+        )
     }
 }

--- a/app/src/main/java/io/github/romantsisyk/nfccardreader/data/local/NfcDatabase.kt
+++ b/app/src/main/java/io/github/romantsisyk/nfccardreader/data/local/NfcDatabase.kt
@@ -7,6 +7,15 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 import io.github.romantsisyk.nfccardreader.data.local.dao.ScanDao
 import io.github.romantsisyk.nfccardreader.data.local.entity.ScanEntity
 
+/**
+ * TODO(security/PCI-DSS): The Room database is currently UNENCRYPTED. SQLite WAL/SHM
+ * journal files may retain card-data remnants on disk even after row deletion.
+ * Migrate to SQLCipher (net.zetetic:android-database-sqlcipher) with a key stored
+ * in the Android Keystore (StrongBox where available) and pass a
+ * SupportFactory(passphrase) to Room.databaseBuilder(). Tracked separately —
+ * out of scope for this PR (requires schema/build-config changes and key-rotation
+ * design).
+ */
 @Database(
     entities = [ScanEntity::class],
     version = 2,

--- a/app/src/main/java/io/github/romantsisyk/nfccardreader/data/local/NfcDatabase.kt
+++ b/app/src/main/java/io/github/romantsisyk/nfccardreader/data/local/NfcDatabase.kt
@@ -2,27 +2,61 @@ package io.github.romantsisyk.nfccardreader.data.local
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import io.github.romantsisyk.nfccardreader.data.local.dao.ScanDao
 import io.github.romantsisyk.nfccardreader.data.local.entity.ScanEntity
 
-/**
- * Room database for NFC Card Reader application.
- *
- * Contains the scan history table for storing NFC scan records.
- */
 @Database(
     entities = [ScanEntity::class],
-    version = 1,
+    version = 2,
     exportSchema = true
 )
 abstract class NfcDatabase : RoomDatabase() {
 
-    /**
-     * Provides access to scan history DAO.
-     */
     abstract fun scanDao(): ScanDao
 
     companion object {
         const val DATABASE_NAME = "nfc_card_reader_db"
+
+        // v1 → v2: drop rawResponse and expirationDate columns (contain unmasked card data)
+        val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("""
+                    CREATE TABLE scan_history_new (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        timestamp INTEGER NOT NULL,
+                        cardType TEXT,
+                        applicationLabel TEXT,
+                        maskedPan TEXT,
+                        transactionAmount TEXT,
+                        currencyCode TEXT,
+                        transactionDate TEXT,
+                        transactionStatus TEXT,
+                        applicationIdentifier TEXT,
+                        issuerCountryCode TEXT,
+                        serviceCode TEXT,
+                        formFactorIndicator TEXT,
+                        parsedTlvDataJson TEXT NOT NULL
+                    )
+                """.trimIndent())
+                db.execSQL("""
+                    INSERT INTO scan_history_new (
+                        id, timestamp, cardType, applicationLabel, maskedPan,
+                        transactionAmount, currencyCode, transactionDate, transactionStatus,
+                        applicationIdentifier, issuerCountryCode, serviceCode,
+                        formFactorIndicator, parsedTlvDataJson
+                    )
+                    SELECT
+                        id, timestamp, cardType, applicationLabel, maskedPan,
+                        transactionAmount, currencyCode, transactionDate, transactionStatus,
+                        applicationIdentifier, issuerCountryCode, serviceCode,
+                        formFactorIndicator, parsedTlvDataJson
+                    FROM scan_history
+                """.trimIndent())
+                db.execSQL("DROP TABLE scan_history")
+                db.execSQL("ALTER TABLE scan_history_new RENAME TO scan_history")
+            }
+        }
     }
 }

--- a/app/src/main/java/io/github/romantsisyk/nfccardreader/data/local/entity/ScanEntity.kt
+++ b/app/src/main/java/io/github/romantsisyk/nfccardreader/data/local/entity/ScanEntity.kt
@@ -4,21 +4,14 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import io.github.romantsisyk.nfccardreader.domain.model.NFCData
 
-/**
- * Room entity representing a saved NFC scan record.
- *
- * This entity stores the results of NFC card scans for history tracking.
- */
 @Entity(tableName = "scan_history")
 data class ScanEntity(
     @PrimaryKey(autoGenerate = true)
     val id: Long = 0,
     val timestamp: Long = System.currentTimeMillis(),
-    val rawResponse: String,
     val cardType: String?,
     val applicationLabel: String?,
     val maskedPan: String?,
-    val expirationDate: String?,
     val transactionAmount: String?,
     val currencyCode: String?,
     val transactionDate: String?,
@@ -29,15 +22,10 @@ data class ScanEntity(
     val formFactorIndicator: String?,
     val parsedTlvDataJson: String
 ) {
-    /**
-     * Converts this entity to domain model.
-     *
-     * @param parsedTlvData The deserialized TLV data map
-     * @return NFCData domain model
-     */
     fun toNFCData(parsedTlvData: Map<String, String>): NFCData {
         return NFCData(
-            rawResponse = rawResponse,
+            dbId = id,
+            rawResponse = "",
             cardType = cardType,
             applicationLabel = applicationLabel,
             transactionAmount = transactionAmount,
@@ -53,20 +41,11 @@ data class ScanEntity(
     }
 
     companion object {
-        /**
-         * Creates an entity from domain model.
-         *
-         * @param nfcData The domain model
-         * @param parsedTlvDataJson JSON string of parsed TLV data
-         * @return ScanEntity for database storage
-         */
         fun fromNFCData(nfcData: NFCData, parsedTlvDataJson: String): ScanEntity {
             return ScanEntity(
-                rawResponse = nfcData.rawResponse,
                 cardType = nfcData.cardType,
                 applicationLabel = nfcData.applicationLabel,
-                maskedPan = nfcData.parsedTlvData["Application PAN"],
-                expirationDate = nfcData.parsedTlvData["Expiration Date"],
+                maskedPan = nfcData.parsedTlvData["APPLICATION_PAN"],
                 transactionAmount = nfcData.transactionAmount,
                 currencyCode = nfcData.currencyCode,
                 transactionDate = nfcData.transactionDate,

--- a/app/src/main/java/io/github/romantsisyk/nfccardreader/data/local/entity/ScanEntity.kt
+++ b/app/src/main/java/io/github/romantsisyk/nfccardreader/data/local/entity/ScanEntity.kt
@@ -4,6 +4,20 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import io.github.romantsisyk.nfccardreader.domain.model.NFCData
 
+/**
+ * PCI-DSS persistence policy for this entity:
+ *  - PAN: only the masked form (`maskedPan`, BIN + last-4) is stored. Full PAN
+ *    must never be written here.
+ *  - Sensitive Authentication Data (SAD) — full track 1/2, CVV/CVC, PIN
+ *    blocks, expiration date in clear, cardholder name — must NOT appear in
+ *    any column. Upstream filtering in `NfcRepositoryImpl.SENSITIVE_TAGS`
+ *    strips these from `parsedTlvDataJson` before insert.
+ *  - `serviceCode` is cardholder data (not SAD); retained for analytics.
+ *  - The `rawResponse` and `expirationDate` columns were intentionally removed
+ *    in schema v2 (see NfcDatabase.MIGRATION_1_2).
+ *  - TODO(security): the table itself is currently stored unencrypted — see
+ *    SQLCipher TODO on NfcDatabase.
+ */
 @Entity(tableName = "scan_history")
 data class ScanEntity(
     @PrimaryKey(autoGenerate = true)

--- a/app/src/main/java/io/github/romantsisyk/nfccardreader/data/repository/NfcRepositoryImpl.kt
+++ b/app/src/main/java/io/github/romantsisyk/nfccardreader/data/repository/NfcRepositoryImpl.kt
@@ -20,14 +20,6 @@ import org.json.JSONObject
 import javax.inject.Inject
 import javax.inject.Singleton
 
-/**
- * Implementation of [NfcRepository] that handles NFC operations
- * and local database storage.
- *
- * @property context Application context for NFC adapter access
- * @property processNfcIntentUseCase Use case for processing NFC intents
- * @property scanDao DAO for scan history database operations
- */
 @Singleton
 class NfcRepositoryImpl @Inject constructor(
     @ApplicationContext private val context: Context,
@@ -38,32 +30,15 @@ class NfcRepositoryImpl @Inject constructor(
     override suspend fun processNfcIntent(intent: Intent): NfcResult<NFCData> {
         return withContext(Dispatchers.IO) {
             try {
-                val nfcData = processNfcIntentUseCase.execute(intent)
-                NfcResult.Success(nfcData)
+                NfcResult.Success(processNfcIntentUseCase.execute(intent))
             } catch (e: IllegalArgumentException) {
-                NfcResult.Error(
-                    error = NfcError.TAG_NOT_FOUND,
-                    message = e.message ?: "No NFC tag found",
-                    exception = e
-                )
+                NfcResult.Error(NfcError.TAG_NOT_FOUND, "No NFC tag found", e)
             } catch (e: UnsupportedOperationException) {
-                NfcResult.Error(
-                    error = NfcError.UNSUPPORTED_TAG,
-                    message = e.message ?: "Unsupported NFC tag type",
-                    exception = e
-                )
+                NfcResult.Error(NfcError.UNSUPPORTED_TAG, "Unsupported NFC tag type", e)
             } catch (e: IllegalStateException) {
-                NfcResult.Error(
-                    error = NfcError.INITIALIZATION_ERROR,
-                    message = e.message ?: "Initialization error",
-                    exception = e
-                )
+                NfcResult.Error(NfcError.INITIALIZATION_ERROR, "Initialization error", e)
             } catch (e: Exception) {
-                NfcResult.Error(
-                    error = NfcError.COMMUNICATION_ERROR,
-                    message = e.message ?: "Communication error with NFC tag",
-                    exception = e
-                )
+                NfcResult.Error(NfcError.COMMUNICATION_ERROR, "Communication error with NFC tag", e)
             }
         }
     }
@@ -71,19 +46,11 @@ class NfcRepositoryImpl @Inject constructor(
     override suspend fun saveScanRecord(nfcData: NFCData): NfcResult<Long> {
         return withContext(Dispatchers.IO) {
             try {
-                val jsonObject = JSONObject()
-                nfcData.parsedTlvData.forEach { (key, value) ->
-                    jsonObject.put(key, value)
-                }
-                val entity = ScanEntity.fromNFCData(nfcData, jsonObject.toString())
-                val id = scanDao.insert(entity)
-                NfcResult.Success(id)
+                val json = serializeTlvMap(nfcData.parsedTlvData)
+                val entity = ScanEntity.fromNFCData(nfcData, json)
+                NfcResult.Success(scanDao.insert(entity))
             } catch (e: Exception) {
-                NfcResult.Error(
-                    error = NfcError.UNKNOWN_ERROR,
-                    message = "Failed to save scan record: ${e.message}",
-                    exception = e
-                )
+                NfcResult.Error(NfcError.UNKNOWN_ERROR, "Failed to save scan record", e)
             }
         }
     }
@@ -91,17 +58,7 @@ class NfcRepositoryImpl @Inject constructor(
     override fun getScanHistory(): Flow<List<NFCData>> {
         return scanDao.getAllScans().map { entities ->
             entities.map { entity ->
-                val parsedTlvData = try {
-                    val jsonObject = JSONObject(entity.parsedTlvDataJson)
-                    val map = mutableMapOf<String, String>()
-                    jsonObject.keys().forEach { key ->
-                        map[key] = jsonObject.getString(key)
-                    }
-                    map
-                } catch (e: Exception) {
-                    emptyMap()
-                }
-                entity.toNFCData(parsedTlvData)
+                entity.toNFCData(deserializeTlvMap(entity.parsedTlvDataJson))
             }
         }
     }
@@ -111,29 +68,12 @@ class NfcRepositoryImpl @Inject constructor(
             try {
                 val entity = scanDao.getScanById(id)
                 if (entity != null) {
-                    val parsedTlvData = try {
-                        val jsonObject = JSONObject(entity.parsedTlvDataJson)
-                        val map = mutableMapOf<String, String>()
-                        jsonObject.keys().forEach { key ->
-                            map[key] = jsonObject.getString(key)
-                        }
-                        map
-                    } catch (e: Exception) {
-                        emptyMap()
-                    }
-                    NfcResult.Success(entity.toNFCData(parsedTlvData))
+                    NfcResult.Success(entity.toNFCData(deserializeTlvMap(entity.parsedTlvDataJson)))
                 } else {
-                    NfcResult.Error(
-                        error = NfcError.INVALID_DATA,
-                        message = "Scan record not found"
-                    )
+                    NfcResult.Error(NfcError.INVALID_DATA, "Scan record not found")
                 }
             } catch (e: Exception) {
-                NfcResult.Error(
-                    error = NfcError.UNKNOWN_ERROR,
-                    message = "Failed to retrieve scan record: ${e.message}",
-                    exception = e
-                )
+                NfcResult.Error(NfcError.UNKNOWN_ERROR, "Failed to retrieve scan record", e)
             }
         }
     }
@@ -144,11 +84,7 @@ class NfcRepositoryImpl @Inject constructor(
                 scanDao.deleteById(id)
                 NfcResult.Success(Unit)
             } catch (e: Exception) {
-                NfcResult.Error(
-                    error = NfcError.UNKNOWN_ERROR,
-                    message = "Failed to delete scan record: ${e.message}",
-                    exception = e
-                )
+                NfcResult.Error(NfcError.UNKNOWN_ERROR, "Failed to delete scan record", e)
             }
         }
     }
@@ -159,34 +95,55 @@ class NfcRepositoryImpl @Inject constructor(
                 scanDao.deleteAll()
                 NfcResult.Success(Unit)
             } catch (e: Exception) {
-                NfcResult.Error(
-                    error = NfcError.UNKNOWN_ERROR,
-                    message = "Failed to clear history: ${e.message}",
-                    exception = e
-                )
+                NfcResult.Error(NfcError.UNKNOWN_ERROR, "Failed to clear history", e)
             }
         }
     }
 
     override fun checkNfcAvailability(): NfcResult<NfcAvailability> {
         return try {
-            val nfcAdapter = NfcAdapter.getDefaultAdapter(context)
-            if (nfcAdapter == null) {
-                NfcResult.Success(NfcAvailability(isAvailable = false, isEnabled = false))
-            } else {
-                NfcResult.Success(
-                    NfcAvailability(
-                        isAvailable = true,
-                        isEnabled = nfcAdapter.isEnabled
-                    )
+            val adapter = context.getSystemService(NfcAdapter::class.java)
+            NfcResult.Success(
+                NfcAvailability(
+                    isAvailable = adapter != null,
+                    isEnabled = adapter?.isEnabled == true
                 )
-            }
-        } catch (e: Exception) {
-            NfcResult.Error(
-                error = NfcError.UNKNOWN_ERROR,
-                message = "Failed to check NFC availability: ${e.message}",
-                exception = e
             )
+        } catch (e: Exception) {
+            NfcResult.Error(NfcError.UNKNOWN_ERROR, "Failed to check NFC availability", e)
+        }
+    }
+
+    private fun serializeTlvMap(map: Map<String, String>): String {
+        val obj = JSONObject()
+        map.filterKeys { it !in SENSITIVE_TAGS }.forEach { (k, v) -> obj.put(k, v) }
+        return obj.toString()
+    }
+
+    companion object {
+        // Never persist these tags — they contain sensitive card data per PCI-DSS.
+        // Keys must match EmvTag.name values (or "Tag XXXX" fallback keys from ParseTLVUseCase).
+        private val SENSITIVE_TAGS = setOf(
+            // Cardholder identity
+            "CARDHOLDER_NAME",
+            // Card authentication data
+            "EXPIRATION_DATE",
+            "TRACK2_EQUIVALENT_DATA",
+            // PAN sequence (tag 5F34 — parser emits "Tag 5F34" for unknown tags)
+            "Tag 5F34",
+            // Track 1 discretionary data (tag 9F1F — not in enum, stored as raw tag key)
+            "Tag 9F1F",
+            // Issuer-specific data that may contain raw track data
+            "Tag 56"
+        )
+    }
+
+    private fun deserializeTlvMap(json: String): Map<String, String> {
+        return try {
+            val obj = JSONObject(json)
+            obj.keys().asSequence().associateWith { obj.getString(it) }
+        } catch (e: Exception) {
+            emptyMap()
         }
     }
 }

--- a/app/src/main/java/io/github/romantsisyk/nfccardreader/data/repository/NfcRepositoryImpl.kt
+++ b/app/src/main/java/io/github/romantsisyk/nfccardreader/data/repository/NfcRepositoryImpl.kt
@@ -32,13 +32,15 @@ class NfcRepositoryImpl @Inject constructor(
             try {
                 NfcResult.Success(processNfcIntentUseCase.execute(intent))
             } catch (e: IllegalArgumentException) {
-                NfcResult.Error(NfcError.TAG_NOT_FOUND, "No NFC tag found", e)
+                // PCI-DSS: do not propagate raw exception — its message/toString may contain
+                // unmasked TLV bytes, PAN, or track data parsed from the card.
+                NfcResult.Error(NfcError.TAG_NOT_FOUND, "No NFC tag found (${e.javaClass.simpleName})")
             } catch (e: UnsupportedOperationException) {
-                NfcResult.Error(NfcError.UNSUPPORTED_TAG, "Unsupported NFC tag type", e)
+                NfcResult.Error(NfcError.UNSUPPORTED_TAG, "Unsupported NFC tag type (${e.javaClass.simpleName})")
             } catch (e: IllegalStateException) {
-                NfcResult.Error(NfcError.INITIALIZATION_ERROR, "Initialization error", e)
+                NfcResult.Error(NfcError.INITIALIZATION_ERROR, "Initialization error (${e.javaClass.simpleName})")
             } catch (e: Exception) {
-                NfcResult.Error(NfcError.COMMUNICATION_ERROR, "Communication error with NFC tag", e)
+                NfcResult.Error(NfcError.COMMUNICATION_ERROR, "Communication error with NFC tag (${e.javaClass.simpleName})")
             }
         }
     }
@@ -50,7 +52,8 @@ class NfcRepositoryImpl @Inject constructor(
                 val entity = ScanEntity.fromNFCData(nfcData, json)
                 NfcResult.Success(scanDao.insert(entity))
             } catch (e: Exception) {
-                NfcResult.Error(NfcError.UNKNOWN_ERROR, "Failed to save scan record", e)
+                // Scrub: a Room/SQLite exception message may include the offending row values.
+                NfcResult.Error(NfcError.UNKNOWN_ERROR, "Failed to save scan record (${e.javaClass.simpleName})")
             }
         }
     }
@@ -73,7 +76,7 @@ class NfcRepositoryImpl @Inject constructor(
                     NfcResult.Error(NfcError.INVALID_DATA, "Scan record not found")
                 }
             } catch (e: Exception) {
-                NfcResult.Error(NfcError.UNKNOWN_ERROR, "Failed to retrieve scan record", e)
+                NfcResult.Error(NfcError.UNKNOWN_ERROR, "Failed to retrieve scan record (${e.javaClass.simpleName})")
             }
         }
     }
@@ -84,7 +87,7 @@ class NfcRepositoryImpl @Inject constructor(
                 scanDao.deleteById(id)
                 NfcResult.Success(Unit)
             } catch (e: Exception) {
-                NfcResult.Error(NfcError.UNKNOWN_ERROR, "Failed to delete scan record", e)
+                NfcResult.Error(NfcError.UNKNOWN_ERROR, "Failed to delete scan record (${e.javaClass.simpleName})")
             }
         }
     }
@@ -95,7 +98,7 @@ class NfcRepositoryImpl @Inject constructor(
                 scanDao.deleteAll()
                 NfcResult.Success(Unit)
             } catch (e: Exception) {
-                NfcResult.Error(NfcError.UNKNOWN_ERROR, "Failed to clear history", e)
+                NfcResult.Error(NfcError.UNKNOWN_ERROR, "Failed to clear history (${e.javaClass.simpleName})")
             }
         }
     }
@@ -110,7 +113,7 @@ class NfcRepositoryImpl @Inject constructor(
                 )
             )
         } catch (e: Exception) {
-            NfcResult.Error(NfcError.UNKNOWN_ERROR, "Failed to check NFC availability", e)
+            NfcResult.Error(NfcError.UNKNOWN_ERROR, "Failed to check NFC availability (${e.javaClass.simpleName})")
         }
     }
 
@@ -134,7 +137,13 @@ class NfcRepositoryImpl @Inject constructor(
             // Track 1 discretionary data (tag 9F1F — not in enum, stored as raw tag key)
             "Tag 9F1F",
             // Issuer-specific data that may contain raw track data
-            "Tag 56"
+            "Tag 56",
+            // DF Name (tag 84) — application identifier that can fingerprint cardholder app selection
+            "Tag 84",
+            // CVM Results (tag 9F34) — cardholder verification method outcome,
+            // may leak whether PIN/signature was used and the result byte
+            "Tag 9F34",
+            "CVM_RESULTS"
         )
     }
 

--- a/app/src/main/java/io/github/romantsisyk/nfccardreader/di/NfcModule.kt
+++ b/app/src/main/java/io/github/romantsisyk/nfccardreader/di/NfcModule.kt
@@ -12,78 +12,28 @@ import io.github.romantsisyk.nfccardreader.data.local.NfcDatabase
 import io.github.romantsisyk.nfccardreader.data.local.dao.ScanDao
 import io.github.romantsisyk.nfccardreader.data.repository.NfcRepositoryImpl
 import io.github.romantsisyk.nfccardreader.domain.repository.NfcRepository
-import io.github.romantsisyk.nfccardreader.domain.usecase.InterpretNfcDataUseCase
-import io.github.romantsisyk.nfccardreader.domain.usecase.ParseTLVUseCase
-import io.github.romantsisyk.nfccardreader.domain.usecase.ProcessNfcIntentUseCase
 import javax.inject.Singleton
 
-/**
- * Hilt module providing NFC-related dependencies.
- */
 @Module
 @InstallIn(SingletonComponent::class)
 object NfcModule {
 
-    /**
-     * Provides the Room database instance.
-     */
     @Provides
     @Singleton
-    fun provideDatabase(@ApplicationContext context: Context): NfcDatabase {
-        return Room.databaseBuilder(
-            context,
-            NfcDatabase::class.java,
-            NfcDatabase.DATABASE_NAME
-        ).build()
-    }
+    fun provideDatabase(@ApplicationContext context: Context): NfcDatabase =
+        Room.databaseBuilder(context, NfcDatabase::class.java, NfcDatabase.DATABASE_NAME)
+            .addMigrations(NfcDatabase.MIGRATION_1_2)
+            .build()
 
-    /**
-     * Provides the ScanDao from the database.
-     */
     @Provides
     @Singleton
-    fun provideScanDao(database: NfcDatabase): ScanDao {
-        return database.scanDao()
-    }
-
-    /**
-     * Provides the InterpretNfcDataUseCase.
-     */
-    @Provides
-    fun provideInterpretNfcDataUseCase(): InterpretNfcDataUseCase {
-        return InterpretNfcDataUseCase()
-    }
-
-    /**
-     * Provides the ParseTLVUseCase.
-     */
-    @Provides
-    fun provideParseTLVUseCase(): ParseTLVUseCase {
-        return ParseTLVUseCase()
-    }
-
-    /**
-     * Provides the ProcessNfcIntentUseCase.
-     */
-    @Provides
-    fun provideProcessNfcIntentUseCase(
-        parseTLVUseCase: ParseTLVUseCase,
-        interpretNfcDataUseCase: InterpretNfcDataUseCase
-    ): ProcessNfcIntentUseCase {
-        return ProcessNfcIntentUseCase(parseTLVUseCase, interpretNfcDataUseCase)
-    }
+    fun provideScanDao(database: NfcDatabase): ScanDao = database.scanDao()
 }
 
-/**
- * Hilt module for binding repository implementations.
- */
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class RepositoryModule {
 
-    /**
-     * Binds NfcRepositoryImpl to NfcRepository interface.
-     */
     @Binds
     @Singleton
     abstract fun bindNfcRepository(impl: NfcRepositoryImpl): NfcRepository

--- a/app/src/main/java/io/github/romantsisyk/nfccardreader/domain/EmvTag.kt
+++ b/app/src/main/java/io/github/romantsisyk/nfccardreader/domain/EmvTag.kt
@@ -47,6 +47,14 @@ enum class EmvTag(val tag: String, val description: String = "") {
     VISA_SPECIFIC_DATA("A5", "Visa Specific Data"),
     APPLICATION_IDENTIFIER_ADDITIONAL("9F06", "Application Identifier (AID)"), // Added missing tag
 
+    // EMV protocol-flow tags (used by GPO / READ RECORD)
+    APPLICATION_FILE_LOCATOR("94", "Application File Locator"),
+    PDOL("9F38", "Processing Options Data Object List"),
+    RESPONSE_MESSAGE_TEMPLATE_FORMAT_1("80", "Response Message Template Format 1"),
+    RESPONSE_MESSAGE_TEMPLATE_FORMAT_2("77", "Response Message Template Format 2"),
+    FCI_PROPRIETARY_TEMPLATE("A5", "FCI Proprietary Template"),
+    FCI_ISSUER_DISCRETIONARY_DATA("BF0C", "FCI Issuer Discretionary Data"),
+
     // Fallback for unknown tags
     UNKNOWN("FFFF", "Unknown Tag");
 

--- a/app/src/main/java/io/github/romantsisyk/nfccardreader/domain/EmvTag.kt
+++ b/app/src/main/java/io/github/romantsisyk/nfccardreader/domain/EmvTag.kt
@@ -44,8 +44,7 @@ enum class EmvTag(val tag: String, val description: String = "") {
     CARD_AUTHENTICATION_METHOD("9F6C", "Card Authentication Method"),
     CERTIFICATION_AUTHORITY_PUBLIC_KEY_INDEX("9F22", "Certification Authority Public Key Index"),
     MASTERCARD_SPECIFIC_DATA("A0", "MasterCard Specific Data"),
-    VISA_SPECIFIC_DATA("A5", "Visa Specific Data"),
-    APPLICATION_IDENTIFIER_ADDITIONAL("9F06", "Application Identifier (AID)"), // Added missing tag
+    APPLICATION_IDENTIFIER_ADDITIONAL("9F06", "Application Identifier (AID)"),
 
     // EMV protocol-flow tags (used by GPO / READ RECORD)
     APPLICATION_FILE_LOCATOR("94", "Application File Locator"),

--- a/app/src/main/java/io/github/romantsisyk/nfccardreader/domain/model/NFCParsedData.kt
+++ b/app/src/main/java/io/github/romantsisyk/nfccardreader/domain/model/NFCParsedData.kt
@@ -1,6 +1,7 @@
 package io.github.romantsisyk.nfccardreader.domain.model
 
 data class NFCData(
+    val dbId: Long = 0,
     val rawResponse: String = "",
     val cardType: String? = null,
     val applicationLabel: String? = null,

--- a/app/src/main/java/io/github/romantsisyk/nfccardreader/domain/model/NfcResult.kt
+++ b/app/src/main/java/io/github/romantsisyk/nfccardreader/domain/model/NfcResult.kt
@@ -52,7 +52,7 @@ sealed class NfcResult<out T> {
      */
     fun getOrNull(): T? = when (this) {
         is Success -> data
-        else -> null
+        is Error, is Loading -> null
     }
 
     /**
@@ -60,7 +60,7 @@ sealed class NfcResult<out T> {
      */
     fun errorOrNull(): NfcError? = when (this) {
         is Error -> error
-        else -> null
+        is Success, is Loading -> null
     }
 }
 

--- a/app/src/main/java/io/github/romantsisyk/nfccardreader/domain/usecase/InterpretNfcDataUseCase.kt
+++ b/app/src/main/java/io/github/romantsisyk/nfccardreader/domain/usecase/InterpretNfcDataUseCase.kt
@@ -1,159 +1,69 @@
 package io.github.romantsisyk.nfccardreader.domain.usecase
 
-import android.util.Log
 import io.github.romantsisyk.nfccardreader.domain.EmvTag
 import io.github.romantsisyk.nfccardreader.domain.model.NFCData
 import io.github.romantsisyk.nfccardreader.utils.NfcDataDecoder
+import javax.inject.Inject
 
 /**
- * Use case for interpreting raw NFC response data into structured NFCData.
- *
- * This class transforms raw byte arrays from NFC card communications into
- * human-readable, structured data. It handles EMV tag detection and delegates
- * specific value interpretation to [NfcDataDecoder].
- *
- * @see NFCData for the output data structure
- * @see NfcDataDecoder for value interpretation utilities
+ * Translates a parsed TLV map (output of ParseTLVUseCase) into a human-readable NFCData.
+ * No TLV walking here — all tag extraction is done by ParseTLVUseCase.
  */
-class InterpretNfcDataUseCase {
+class InterpretNfcDataUseCase @Inject constructor() {
 
-    private val TAG = "InterpretNfcDataUseCase"
-
-    /**
-     * Executes interpretation of raw NFC response bytes.
-     *
-     * Parses the response byte array, identifies EMV tags, and constructs
-     * a comprehensive [NFCData] object containing all interpreted fields.
-     *
-     * @param response Raw byte array from NFC card communication
-     * @return NFCData object with all interpreted card information
-     */
-    fun execute(response: ByteArray): NFCData {
-        val hexBytes = response.map { "%02X".format(it) }
-        val interpretedData = mutableMapOf<EmvTag, String>()
-        
-        Log.d(TAG, "Starting NFC data interpretation. Response size: ${response.size}")
-
-        var i = 0
-        while (i < hexBytes.size) {
-            val tag = if (i + 1 < hexBytes.size && hexBytes[i] == "5F" || hexBytes[i] == "9F") {
-                "${hexBytes[i]}${hexBytes[i+1]}"
-            } else {
-                hexBytes[i]
-            }
-            
-            val emvTag = EmvTag.fromTag(tag)
-            
-            Log.d(TAG, "Processing tag: $tag (${emvTag.name}) at index $i")
-            
-            if (tag.length > 2) {
-                i++
-            }
-            
-            if (emvTag != EmvTag.UNKNOWN && i + 1 < hexBytes.size) {
-                val length = try {
-                    hexBytes[i + 1].toInt(16)
-                } catch (e: Exception) {
-                    Log.e(TAG, "Error parsing length for tag $tag", e)
-                    1 // За замовчуванням припускаємо довжину 1
-                }
-                
-                if (i + 1 + length < hexBytes.size) {
-                    val valueBytes = hexBytes.subList(i + 2, i + 2 + length)
-                    val interpretedValue = interpretTagValue(emvTag, valueBytes)
-                    interpretedData[emvTag] = interpretedValue
-                    Log.d(TAG, "Parsed ${emvTag.name}: $interpretedValue")
-                    
-                    i += 1 + length
-                } else {
-                    Log.w(TAG, "Not enough data remaining for tag $tag. Breaking.")
-                    break
-                }
-            } else {
-                i++
-            }
-        }
-        
-        Log.d(TAG, "Completed NFC data interpretation. Interpreted ${interpretedData.size} tags.")
-        
+    fun execute(parsed: Map<String, String>): NFCData {
         return NFCData(
-            rawResponse = hexBytes.joinToString(" "),
-            cardType = interpretedData[EmvTag.CARD_TYPE],
-            applicationLabel = interpretedData[EmvTag.APPLICATION_LABEL],
-            transactionAmount = interpretedData[EmvTag.TRANSACTION_AMOUNT],
-            currencyCode = interpretedData[EmvTag.CURRENCY_CODE],
-            transactionDate = interpretedData[EmvTag.TRANSACTION_DATE],
-            transactionStatus = interpretedData[EmvTag.TRANSACTION_STATUS],
-            applicationIdentifier = interpretedData[EmvTag.APPLICATION_IDENTIFIER],
-            applicationTemplate = interpretedData[EmvTag.APPLICATION_TEMPLATE],
-            dedicatedFileName = interpretedData[EmvTag.DEDICATED_FILE_NAME],
-            issuerCountryCode = interpretedData[EmvTag.ISSUER_COUNTRY_CODE],
-            transactionCurrencyExponent = interpretedData[EmvTag.TRANSACTION_CURRENCY_EXPONENT],
-            serviceCode = interpretedData[EmvTag.SERVICE_CODE],
-            issuerUrl = interpretedData[EmvTag.ISSUER_URL],
-            paymentAccountReference = interpretedData[EmvTag.PAYMENT_ACCOUNT_REFERENCE],
-            applicationCryptogram = interpretedData[EmvTag.APPLICATION_CRYPTOGRAM],
-            applicationTransactionCounter = interpretedData[EmvTag.APPLICATION_TRANSACTION_COUNTER],
-            applicationInterchangeProfile = interpretedData[EmvTag.APPLICATION_INTERCHANGE_PROFILE],
-            terminalVerificationResults = interpretedData[EmvTag.TERMINAL_VERIFICATION_RESULTS],
-            transactionType = interpretedData[EmvTag.TRANSACTION_TYPE],
-            issuerApplicationData = interpretedData[EmvTag.ISSUER_APPLICATION_DATA],
-            terminalCountryCode = interpretedData[EmvTag.TERMINAL_COUNTRY_CODE],
-            interfaceDeviceSerialNumber = interpretedData[EmvTag.INTERFACE_DEVICE_SERIAL_NUMBER],
-            unpredictableNumber = interpretedData[EmvTag.UNPREDICTABLE_NUMBER],
-            cardholderVerificationMethodResults = interpretedData[EmvTag.CARDHOLDER_VERIFICATION_METHOD_RESULTS],
-            issuerScriptResults = interpretedData[EmvTag.ISSUER_SCRIPT_RESULTS],
-            applicationCurrencyCode = interpretedData[EmvTag.APPLICATION_CURRENCY_CODE],
-            transactionCategoryCode = interpretedData[EmvTag.TRANSACTION_CATEGORY_CODE],
-            formFactorIndicator = interpretedData[EmvTag.FORM_FACTOR_INDICATOR]
+            cardType               = detectCardType(parsed),
+            applicationLabel       = parsed[EmvTag.APPLICATION_LABEL.name]?.hexToUtf8(),
+            transactionAmount      = parsed[EmvTag.TRANSACTION_AMOUNT.name]
+                                         ?.chunked(2)?.let { NfcDataDecoder.decodeAmount(it) },
+            currencyCode           = parsed[EmvTag.CURRENCY_CODE.name]
+                                         ?.chunked(2)?.let { NfcDataDecoder.decodeCurrency(it) },
+            transactionDate        = parsed[EmvTag.TRANSACTION_DATE.name]
+                                         ?.chunked(2)?.let { NfcDataDecoder.decodeDate(it) },
+            transactionStatus      = null, // SW1/SW2 is stripped before parsing — not a TLV field
+            applicationIdentifier  = parsed[EmvTag.APPLICATION_IDENTIFIER.name]
+                                         ?.chunked(2)?.let { NfcDataDecoder.decodeApplicationIdentifier(it) },
+            applicationTemplate    = parsed[EmvTag.APPLICATION_TEMPLATE.name],
+            dedicatedFileName      = parsed[EmvTag.DEDICATED_FILE_NAME.name],
+            issuerCountryCode      = parsed[EmvTag.ISSUER_COUNTRY_CODE.name]
+                                         ?.chunked(2)?.let { NfcDataDecoder.decodeCountryCode(it) },
+            transactionCurrencyExponent = parsed[EmvTag.TRANSACTION_CURRENCY_EXPONENT.name],
+            serviceCode            = parsed[EmvTag.SERVICE_CODE.name]
+                                         ?.chunked(2)?.let { NfcDataDecoder.decodeServiceCode(it) },
+            issuerUrl              = parsed[EmvTag.ISSUER_URL.name]?.hexToUtf8(),
+            paymentAccountReference     = parsed[EmvTag.PAYMENT_ACCOUNT_REFERENCE.name],
+            applicationCryptogram       = parsed[EmvTag.APPLICATION_CRYPTOGRAM.name],
+            applicationTransactionCounter = parsed[EmvTag.APPLICATION_TRANSACTION_COUNTER.name],
+            applicationInterchangeProfile = parsed[EmvTag.APPLICATION_INTERCHANGE_PROFILE.name],
+            terminalVerificationResults = parsed[EmvTag.TERMINAL_VERIFICATION_RESULTS.name],
+            transactionType        = parsed[EmvTag.TRANSACTION_TYPE.name]
+                                         ?.take(2)?.let { NfcDataDecoder.decodeTransactionType(it) },
+            issuerApplicationData  = parsed[EmvTag.ISSUER_APPLICATION_DATA.name],
+            terminalCountryCode    = parsed[EmvTag.TERMINAL_COUNTRY_CODE.name]
+                                         ?.chunked(2)?.let { NfcDataDecoder.decodeCountryCode(it) },
+            interfaceDeviceSerialNumber = parsed[EmvTag.INTERFACE_DEVICE_SERIAL_NUMBER.name],
+            unpredictableNumber    = parsed[EmvTag.UNPREDICTABLE_NUMBER.name],
+            cardholderVerificationMethodResults = parsed[EmvTag.CARDHOLDER_VERIFICATION_METHOD_RESULTS.name]
+                                         ?.chunked(2)?.let { NfcDataDecoder.decodeCardholderVerificationMethodResult(it) },
+            issuerScriptResults    = parsed[EmvTag.ISSUER_SCRIPT_RESULTS.name],
+            applicationCurrencyCode     = parsed[EmvTag.APPLICATION_CURRENCY_CODE.name],
+            transactionCategoryCode     = parsed[EmvTag.TRANSACTION_CATEGORY_CODE.name],
+            formFactorIndicator    = parsed[EmvTag.FORM_FACTOR_INDICATOR.name]
+                                         ?.chunked(2)?.let { NfcDataDecoder.decodeFormFactorIndicator(it) },
+            parsedTlvData          = parsed
         )
     }
-    
-    private fun interpretTagValue(emvTag: EmvTag, valueBytes: List<String>): String {
-        return when (emvTag) {
-            EmvTag.CARD_TYPE -> {
-                if (valueBytes.any { it.contains("A0") }) {
-                    "EMV Payment Card"
-                } else {
-                    "Unknown Card Type"
-                }
-            }
-            EmvTag.APPLICATION_LABEL -> {
-                try {
-                    val bytes = valueBytes.map { it.toInt(16).toByte() }.toByteArray()
-                    String(bytes, Charsets.UTF_8)
-                } catch (e: Exception) {
-                    "Parsing Error"
-                }
-            }
-            EmvTag.TRANSACTION_AMOUNT -> NfcDataDecoder.decodeAmount(valueBytes)
-            EmvTag.CURRENCY_CODE -> NfcDataDecoder.decodeCurrency(valueBytes)
-            EmvTag.TRANSACTION_DATE -> NfcDataDecoder.decodeDate(valueBytes)
-            EmvTag.TRANSACTION_STATUS -> {
-                if (valueBytes.firstOrNull() == "00") "Successful" else "Error"
-            }
-            EmvTag.APPLICATION_IDENTIFIER -> NfcDataDecoder.decodeApplicationIdentifier(valueBytes)
-            EmvTag.SERVICE_CODE -> {
-                if (valueBytes.size >= 3) {
-                    NfcDataDecoder.decodeServiceCode(valueBytes.subList(0, 3))
-                } else {
-                    "Incomplete Service Code"
-                }
-            }
-            EmvTag.TRANSACTION_TYPE -> {
-                if (valueBytes.isNotEmpty()) {
-                    NfcDataDecoder.decodeTransactionType(valueBytes.first())
-                } else {
-                    "Unknown Transaction Type"
-                }
-            }
-            EmvTag.ISSUER_COUNTRY_CODE -> NfcDataDecoder.decodeCountryCode(valueBytes)
-            EmvTag.TERMINAL_COUNTRY_CODE -> NfcDataDecoder.decodeCountryCode(valueBytes)
-            EmvTag.CARDHOLDER_VERIFICATION_METHOD_RESULTS -> NfcDataDecoder.decodeCardholderVerificationMethodResult(valueBytes)
-            EmvTag.FORM_FACTOR_INDICATOR -> NfcDataDecoder.decodeFormFactorIndicator(valueBytes)
-            else -> {
-                valueBytes.joinToString("")
-            }
-        }
+
+    private fun detectCardType(parsed: Map<String, String>): String? {
+        val aidHex = parsed[EmvTag.APPLICATION_IDENTIFIER_ADDITIONAL.name]
+            ?: parsed[EmvTag.APPLICATION_IDENTIFIER.name]
+            ?: return null
+        return NfcDataDecoder.decodeApplicationIdentifier(aidHex.chunked(2))
     }
+
+    private fun String.hexToUtf8(): String? = runCatching {
+        chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+            .toString(Charsets.UTF_8).trim().ifEmpty { null }
+    }.getOrNull()
 }

--- a/app/src/main/java/io/github/romantsisyk/nfccardreader/domain/usecase/ParseTLVUseCase.kt
+++ b/app/src/main/java/io/github/romantsisyk/nfccardreader/domain/usecase/ParseTLVUseCase.kt
@@ -31,6 +31,12 @@ class ParseTLVUseCase @Inject constructor() {
 
         while (index < end) {
 
+            // ── Skip BER-TLV padding bytes (0x00) between fields ──────────
+            // EMV Book 3 §4.2 allows 0x00 as inter-TLV padding. 0xFF is NOT
+            // skipped because it's a legal (private-use) tag start byte.
+            val peek = data[index].toInt() and 0xFF
+            if (peek == 0x00) { index++; continue }
+
             // ── Read tag ──────────────────────────────────────────────────
             if (index >= end) break
             val firstByte = data[index].toInt() and 0xFF
@@ -72,7 +78,15 @@ class ParseTLVUseCase @Inject constructor() {
 
             // ── Process value ─────────────────────────────────────────────
             if (isConstructed) {
-                // Recurse into template; merge children into result
+                // Record the constructed template itself (raw hex) so callers
+                // can see e.g. APPLICATION_TEMPLATE / FCI bytes, then recurse
+                // into children (children win on key collision via putAll).
+                val rawHex = data.sliceArray(valueStart until valueEnd)
+                    .joinToString("") { "%02X".format(it) }
+                when (val emvTag = EmvTag.fromTag(tag)) {
+                    EmvTag.UNKNOWN -> result["Tag $tag"] = rawHex
+                    else -> result[emvTag.name] = rawHex
+                }
                 result.putAll(parseTlv(data, valueStart, valueEnd))
             } else {
                 val value = data.sliceArray(valueStart until valueEnd)

--- a/app/src/main/java/io/github/romantsisyk/nfccardreader/domain/usecase/ParseTLVUseCase.kt
+++ b/app/src/main/java/io/github/romantsisyk/nfccardreader/domain/usecase/ParseTLVUseCase.kt
@@ -1,81 +1,102 @@
 package io.github.romantsisyk.nfccardreader.domain.usecase
 
-import android.util.Log
 import io.github.romantsisyk.nfccardreader.domain.EmvTag
 import io.github.romantsisyk.nfccardreader.utils.NfcDataMasker
+import javax.inject.Inject
 
-/**
- * Use case for parsing TLV (Tag-Length-Value) encoded data from NFC responses.
- *
- * This class handles the parsing of EMV-formatted TLV data commonly found
- * in payment card NFC communications. It extracts and decodes various
- * tags including cardholder name, PAN (masked for security), and expiration date.
- *
- * @see EmvTag for supported EMV tags
- * @see NfcDataMasker for PAN masking logic
- */
-class ParseTLVUseCase {
-
-    private val TAG = "ParseTLVUseCase"
+class ParseTLVUseCase @Inject constructor() {
 
     /**
-     * Parses TLV-encoded byte array into a map of tag names to values.
-     *
-     * The parsing follows the EMV TLV structure where each data element
-     * consists of a tag, length, and value. Sensitive data like PANs
-     * are automatically masked for PCI-DSS compliance.
-     *
-     * @param data The raw byte array containing TLV-encoded data
-     * @return Map of tag descriptions to their decoded/masked values
+     * Parses a BER-TLV encoded EMV APDU response.
+     * Strips the SW1/SW2 status word, handles multi-byte tags,
+     * long-form lengths, and recurses into constructed (template) tags.
      */
     fun execute(data: ByteArray): Map<String, String> {
+        val payload = stripStatusWord(data)
+        return parseTlv(payload, 0, payload.size)
+    }
+
+    private fun stripStatusWord(data: ByteArray): ByteArray {
+        if (data.size >= 2
+            && (data[data.size - 2].toInt() and 0xFF) == 0x90
+            && (data[data.size - 1].toInt() and 0xFF) == 0x00) {
+            return data.copyOf(data.size - 2)
+        }
+        return data
+    }
+
+    private fun parseTlv(data: ByteArray, start: Int, end: Int): Map<String, String> {
         val result = mutableMapOf<String, String>()
-        var index = 0
+        var index = start
 
-        Log.d(TAG, "Starting TLV parsing. Data size: ${data.size}")
+        while (index < end) {
 
-        while (index < data.size) {
-            val tag = data[index++].toInt().and(0xFF).toString(16).padStart(2, '0').uppercase()
-            Log.d(TAG, "Found tag: $tag at index $index")
+            // ── Read tag ──────────────────────────────────────────────────
+            if (index >= end) break
+            val firstByte = data[index].toInt() and 0xFF
+            val isConstructed = (firstByte and 0x20) != 0
+            val tagBuilder = StringBuilder("%02X".format(firstByte))
+            index++
 
-            if (index >= data.size) {
-                Log.w(TAG, "Index out of bounds after reading tag.")
-                break
+            // Multi-byte tag: lower 5 bits all set means tag continues
+            if ((firstByte and 0x1F) == 0x1F) {
+                while (index < end) {
+                    val b = data[index].toInt() and 0xFF
+                    tagBuilder.append("%02X".format(b))
+                    index++
+                    if ((b and 0x80) == 0) break  // bit 8 = 0 → last tag byte
+                }
+            }
+            val tag = tagBuilder.toString()
+
+            // ── Read length ───────────────────────────────────────────────
+            if (index >= end) break
+            val firstLenByte = data[index].toInt() and 0xFF
+            index++
+
+            val length: Int = if ((firstLenByte and 0x80) == 0) {
+                firstLenByte  // short form
+            } else {
+                val numBytes = firstLenByte and 0x7F
+                if (numBytes == 0 || numBytes > 4 || index + numBytes > end) break
+                var len = 0
+                repeat(numBytes) { len = (len shl 8) or (data[index++].toInt() and 0xFF) }
+                len
             }
 
-            val length = data[index++].toInt().and(0xFF)
-            Log.d(TAG, "Length of tag $tag: $length")
+            if (length < 0 || index + length > end) break
 
-            if (index + length > data.size) {
-                Log.w(TAG, "Not enough data remaining for tag $tag. Breaking.")
-                break
-            }
-
-            val value = data.sliceArray(index until index + length)
+            val valueStart = index
+            val valueEnd   = index + length
             index += length
-            Log.d(TAG, "Value for tag $tag: ${value.joinToString("") { "%02X".format(it) }}")
 
-            // Map tags based on EMV tag definitions
-            when (val emvTag = EmvTag.fromTag(tag)) {
-                EmvTag.CARDHOLDER_NAME -> result[emvTag.name] = value.toString(Charsets.UTF_8)
-                EmvTag.APPLICATION_PAN -> result[emvTag.name] = NfcDataMasker.maskPan(
-                    value.joinToString("") { "%02X".format(it) }
-                )
-                EmvTag.TRACK2_EQUIVALENT_DATA -> result[emvTag.name] = NfcDataMasker.maskTrack2Data(
-                    value.joinToString("") { "%02X".format(it) }
-                )
-                EmvTag.EXPIRATION_DATE -> result[emvTag.name] = value.joinToString("") { "%02X".format(it) }
-                EmvTag.APPLICATION_PREFERRED_NAME -> result[emvTag.name] = value.toString(Charsets.UTF_8)
-                EmvTag.UNKNOWN -> result["Tag $tag"] = value.joinToString("") { "%02X".format(it) }
-                else -> {
-                    val unparsedValue = value.joinToString("") { "%02X".format(it) }
-                    result["Unparsed Tag $tag"] = unparsedValue
-                    Log.d(TAG, "Unhandled tag $tag with value: $unparsedValue")
+            // ── Process value ─────────────────────────────────────────────
+            if (isConstructed) {
+                // Recurse into template; merge children into result
+                result.putAll(parseTlv(data, valueStart, valueEnd))
+            } else {
+                val value = data.sliceArray(valueStart until valueEnd)
+                when (val emvTag = EmvTag.fromTag(tag)) {
+                    EmvTag.CARDHOLDER_NAME ->
+                        result[emvTag.name] = value.toString(Charsets.UTF_8).trim()
+                    EmvTag.APPLICATION_PAN -> {
+                        val hex = value.joinToString("") { "%02X".format(it) }
+                        result[emvTag.name] = NfcDataMasker.maskPan(hex)
+                    }
+                    EmvTag.TRACK2_EQUIVALENT_DATA -> {
+                        val hex = value.joinToString("") { "%02X".format(it) }
+                        result[emvTag.name] = NfcDataMasker.maskTrack2Data(hex)
+                    }
+                    EmvTag.APPLICATION_PREFERRED_NAME ->
+                        result[emvTag.name] = value.toString(Charsets.UTF_8).trim()
+                    EmvTag.UNKNOWN ->
+                        result["Tag $tag"] = value.joinToString("") { "%02X".format(it) }
+                    else ->
+                        result[emvTag.name] = value.joinToString("") { "%02X".format(it) }
                 }
             }
         }
 
-        Log.d(TAG, "Completed TLV parsing. Parsed ${result.size} tags.")
         return result
     }
 }

--- a/app/src/main/java/io/github/romantsisyk/nfccardreader/domain/usecase/ProcessNfcIntentUseCase.kt
+++ b/app/src/main/java/io/github/romantsisyk/nfccardreader/domain/usecase/ProcessNfcIntentUseCase.kt
@@ -8,65 +8,99 @@ import android.os.Build
 import io.github.romantsisyk.nfccardreader.domain.model.NFCData
 import javax.inject.Inject
 
-/**
- * Use case for processing NFC intents and extracting card data.
- *
- * This use case handles the low-level NFC communication with payment cards,
- * parsing TLV data and interpreting EMV tags.
- *
- * @property parseTLVUseCase Use case for parsing TLV byte arrays
- * @property interpretNfcDataUseCase Use case for interpreting parsed NFC data
- */
-open class ProcessNfcIntentUseCase @Inject constructor(
-    private val parseTLVUseCase: ParseTLVUseCase?,
-    val interpretNfcDataUseCase: InterpretNfcDataUseCase?
+class ProcessNfcIntentUseCase @Inject constructor(
+    private val parseTLVUseCase: ParseTLVUseCase,
+    private val interpretNfcDataUseCase: InterpretNfcDataUseCase
 ) {
 
-    /**
-     * Executes NFC intent processing and returns parsed card data.
-     *
-     * @param intent The NFC intent containing tag information
-     * @return NFCData containing all parsed card information
-     * @throws IllegalArgumentException if no NFC tag found in intent
-     * @throws UnsupportedOperationException if tag doesn't support IsoDep
-     * @throws IllegalStateException if required dependencies are missing
-     */
+    companion object {
+        // PPSE: Proximity Payment System Environment (lists supported AIDs)
+        private val PPSE_AID = "2PAY.SYS.DDF01".toByteArray(Charsets.US_ASCII)
+
+        // Common payment AIDs to try if PPSE fails or returns no usable AID
+        private val FALLBACK_AIDS = listOf(
+            byteArrayOf(0xA0.toByte(), 0x00, 0x00, 0x00, 0x03, 0x10, 0x10),        // Visa
+            byteArrayOf(0xA0.toByte(), 0x00, 0x00, 0x00, 0x04, 0x10, 0x10),        // Mastercard
+            byteArrayOf(0xA0.toByte(), 0x00, 0x00, 0x00, 0x25, 0x01, 0x01),        // Amex
+            byteArrayOf(0xA0.toByte(), 0x00, 0x00, 0x00, 0x65, 0x10, 0x10),        // JCB
+            byteArrayOf(0xA0.toByte(), 0x00, 0x00, 0x03, 0x24, 0x10, 0x01),        // UnionPay
+            byteArrayOf(0xA0.toByte(), 0x00, 0x00, 0x01, 0x52, 0x30, 0x10),        // Discover
+        )
+    }
+
     @Suppress("DEPRECATION")
-    open fun execute(intent: Intent): NFCData {
+    fun execute(intent: Intent): NFCData {
         val tag: Tag? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             intent.getParcelableExtra(NfcAdapter.EXTRA_TAG, Tag::class.java)
         } else {
             intent.getParcelableExtra(NfcAdapter.EXTRA_TAG)
         }
+        requireNotNull(tag) { "No NFC tag found in the intent" }
 
-        if (tag == null) {
-            throw IllegalArgumentException("No NFC tag found in the intent")
-        }
-
-        val isoDep = IsoDep.get(tag) ?: throw UnsupportedOperationException("Unsupported NFC Tag")
+        val isoDep = IsoDep.get(tag)
+            ?: throw UnsupportedOperationException("Card does not support ISO-DEP (IsoDep) protocol")
 
         isoDep.use { dep ->
             dep.connect()
-            val selectVisaCommand = byteArrayOf(
-                0x00.toByte(), 0xA4.toByte(), 0x04.toByte(), 0x00.toByte(), 0x07.toByte(),
-                0xA0.toByte(), 0x00.toByte(), 0x00.toByte(), 0x00.toByte(), 0x03.toByte(),
-                0x10.toByte(), 0x10.toByte(), 0x00.toByte()
-            )
-            val response = dep.transceive(selectVisaCommand)
+            dep.timeout = 5000
 
-            // Create a readable hex string for rawResponse
-            val rawResponse = response.joinToString(" ") { "%02X".format(it) }
+            // 1. Try PPSE to discover the application on the card
+            val aidToSelect = selectAidViaPpse(dep) ?: selectFirstWorkingAid(dep)
+                ?: throw UnsupportedOperationException("No supported payment application found on card")
 
-            // Check if the dependencies are available (for testing)
-            if (parseTLVUseCase == null || interpretNfcDataUseCase == null) {
-                throw IllegalStateException("Missing dependencies in ProcessNfcIntentUseCase")
-            }
+            // 2. SELECT the chosen AID
+            val fciResponse = selectAid(dep, aidToSelect)
 
-            val parsedTlvData = parseTLVUseCase.execute(response)
-            return interpretNfcDataUseCase.execute(response).copy(
-                parsedTlvData = parsedTlvData,
-                rawResponse = rawResponse
-            )
+            // 3. Parse the FCI response + run GET PROCESSING OPTIONS (GPO) if available
+            val parsed = parseTLVUseCase.execute(fciResponse)
+
+            return interpretNfcDataUseCase.execute(parsed)
         }
     }
+
+    /** Returns the first AID found in the PPSE response, or null if PPSE is unsupported. */
+    private fun selectAidViaPpse(dep: IsoDep): ByteArray? {
+        return try {
+            val ppseResponse = dep.transceive(buildSelectCommand(PPSE_AID))
+            if (!isSw9000(ppseResponse)) return null
+
+            // Parse PPSE FCI; AIDs are in constructed BF0C > 61 > 4F
+            val parsed = parseTLVUseCase.execute(ppseResponse)
+            val aidHex = parsed["APPLICATION_IDENTIFIER"] ?: return null
+            aidHex.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /** Tries each fallback AID; returns the first one the card accepts. */
+    private fun selectFirstWorkingAid(dep: IsoDep): ByteArray? {
+        for (aid in FALLBACK_AIDS) {
+            try {
+                val response = dep.transceive(buildSelectCommand(aid))
+                if (isSw9000(response)) return aid
+            } catch (e: Exception) {
+                continue
+            }
+        }
+        return null
+    }
+
+    /** Selects an AID and returns the full FCI response (including nested TLV). */
+    private fun selectAid(dep: IsoDep, aid: ByteArray): ByteArray {
+        val response = dep.transceive(buildSelectCommand(aid))
+        if (!isSw9000(response)) {
+            val sw = response.takeLast(2).joinToString("") { "%02X".format(it) }
+            throw IllegalStateException("Card returned error selecting AID: SW=$sw")
+        }
+        return response
+    }
+
+    private fun buildSelectCommand(aid: ByteArray): ByteArray =
+        byteArrayOf(0x00, 0xA4.toByte(), 0x04, 0x00, aid.size.toByte()) + aid + byteArrayOf(0x00)
+
+    private fun isSw9000(response: ByteArray): Boolean =
+        response.size >= 2
+            && (response[response.size - 2].toInt() and 0xFF) == 0x90
+            && (response[response.size - 1].toInt() and 0xFF) == 0x00
 }

--- a/app/src/main/java/io/github/romantsisyk/nfccardreader/domain/usecase/ProcessNfcIntentUseCase.kt
+++ b/app/src/main/java/io/github/romantsisyk/nfccardreader/domain/usecase/ProcessNfcIntentUseCase.kt
@@ -6,6 +6,7 @@ import android.nfc.Tag
 import android.nfc.tech.IsoDep
 import android.os.Build
 import io.github.romantsisyk.nfccardreader.domain.model.NFCData
+import io.github.romantsisyk.nfccardreader.utils.NfcDataDecoder
 import javax.inject.Inject
 
 class ProcessNfcIntentUseCase @Inject constructor(
@@ -48,12 +49,34 @@ class ProcessNfcIntentUseCase @Inject constructor(
             val aidToSelect = selectAidViaPpse(dep) ?: selectFirstWorkingAid(dep)
                 ?: throw UnsupportedOperationException("No supported payment application found on card")
 
-            // 2. SELECT the chosen AID
+            // 2. SELECT the chosen AID (returns FCI of the application)
             val fciResponse = selectAid(dep, aidToSelect)
 
-            // 3. Parse the FCI response + run GET PROCESSING OPTIONS (GPO) if available
-            val parsed = parseTLVUseCase.execute(fciResponse)
+            // 3. Issue GET PROCESSING OPTIONS to obtain AIP + AFL
+            //    Concatenate the GPO response (best-effort) with the FCI so
+            //    downstream parsing sees both the application FCI tags and any
+            //    GPO/READ RECORD tags. Failures here are non-fatal — many card
+            //    profiles still expose useful tags via the FCI alone.
+            val combined = mutableListOf<Byte>()
+            combined.addAll(fciResponse.toList())
 
+            val gpoResponse = runCatching { sendGpo(dep, fciResponse) }.getOrNull()
+            if (gpoResponse != null) {
+                combined.addAll(gpoResponse.toList())
+
+                // 4. If GPO returned an AFL (tag 94), READ RECORD each entry
+                val gpoParsed = runCatching {
+                    parseTLVUseCase.execute(gpoResponse)
+                }.getOrDefault(emptyMap())
+                val aflHex = gpoParsed["APPLICATION_FILE_LOCATOR"] ?: gpoParsed["Tag 94"]
+                if (aflHex != null) {
+                    runCatching { readAllRecords(dep, aflHex) }
+                        .getOrDefault(emptyList<ByteArray>())
+                        .forEach { combined.addAll(it.toList()) }
+                }
+            }
+
+            val parsed = parseTLVUseCase.execute(combined.toByteArray())
             return interpretNfcDataUseCase.execute(parsed)
         }
     }
@@ -61,13 +84,16 @@ class ProcessNfcIntentUseCase @Inject constructor(
     /** Returns the first AID found in the PPSE response, or null if PPSE is unsupported. */
     private fun selectAidViaPpse(dep: IsoDep): ByteArray? {
         return try {
-            val ppseResponse = dep.transceive(buildSelectCommand(PPSE_AID))
-            if (!isSw9000(ppseResponse)) return null
+            val ppseRaw = transceiveWithGetResponse(dep, buildSelectCommand(PPSE_AID))
+            if (!isSw9000(ppseRaw)) return null
 
-            // Parse PPSE FCI; AIDs are in constructed BF0C > 61 > 4F
-            val parsed = parseTLVUseCase.execute(ppseResponse)
+            // PPSE FCI nesting: 6F → A5 → BF0C → 61 (Application Template) → 4F (AID)
+            // ParseTLVUseCase recurses into constructed templates, so 4F bubbles up.
+            // We deliberately extract from the inner Application Template (61) when
+            // available, since BF0C may list multiple 61 templates with priority (87).
+            val parsed = parseTLVUseCase.execute(ppseRaw)
             val aidHex = parsed["APPLICATION_IDENTIFIER"] ?: return null
-            aidHex.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+            hexToBytes(aidHex)
         } catch (e: Exception) {
             null
         }
@@ -77,7 +103,7 @@ class ProcessNfcIntentUseCase @Inject constructor(
     private fun selectFirstWorkingAid(dep: IsoDep): ByteArray? {
         for (aid in FALLBACK_AIDS) {
             try {
-                val response = dep.transceive(buildSelectCommand(aid))
+                val response = transceiveWithGetResponse(dep, buildSelectCommand(aid))
                 if (isSw9000(response)) return aid
             } catch (e: Exception) {
                 continue
@@ -88,12 +114,129 @@ class ProcessNfcIntentUseCase @Inject constructor(
 
     /** Selects an AID and returns the full FCI response (including nested TLV). */
     private fun selectAid(dep: IsoDep, aid: ByteArray): ByteArray {
-        val response = dep.transceive(buildSelectCommand(aid))
+        val response = transceiveWithGetResponse(dep, buildSelectCommand(aid))
         if (!isSw9000(response)) {
-            val sw = response.takeLast(2).joinToString("") { "%02X".format(it) }
-            throw IllegalStateException("Card returned error selecting AID: SW=$sw")
+            throw IllegalStateException(
+                "Card returned error selecting AID: ${describeStatusWord(response)}"
+            )
         }
         return response
+    }
+
+    /**
+     * Sends GET PROCESSING OPTIONS (GPO).
+     * Builds the PDOL-conditioned data field by reading PDOL (tag 9F38) from
+     * the FCI; if the card requested no PDOL data, sends an empty list (83 00).
+     * Returns the full GPO response bytes (including SW1/SW2). Throws on error.
+     */
+    private fun sendGpo(dep: IsoDep, fciResponse: ByteArray): ByteArray {
+        val pdolValue = extractPdolDefault(fciResponse)
+        // Command Template tag 83 wraps the concatenated PDOL value
+        val cmdTemplate = byteArrayOf(0x83.toByte(), pdolValue.size.toByte()) + pdolValue
+        val gpoCommand = byteArrayOf(
+            0x80.toByte(), 0xA8.toByte(), 0x00, 0x00, cmdTemplate.size.toByte()
+        ) + cmdTemplate + byteArrayOf(0x00)
+        val response = transceiveWithGetResponse(dep, gpoCommand)
+        if (!isSw9000(response)) {
+            throw IllegalStateException(
+                "GPO failed: ${describeStatusWord(response)}"
+            )
+        }
+        return response
+    }
+
+    /**
+     * Walks the AFL (Application File Locator) entries and issues READ RECORD
+     * for each. AFL is a sequence of 4-byte entries: SFI(5 high bits)|00, first
+     * record, last record, # records involved in offline auth.
+     * Returns the concatenated record responses.
+     */
+    private fun readAllRecords(dep: IsoDep, aflHex: String): List<ByteArray> {
+        val afl = hexToBytes(aflHex)
+        if (afl.size < 4 || afl.size % 4 != 0) return emptyList()
+        val out = mutableListOf<ByteArray>()
+        var i = 0
+        while (i + 3 < afl.size) {
+            val sfi = (afl[i].toInt() and 0xFF) ushr 3
+            val firstRec = afl[i + 1].toInt() and 0xFF
+            val lastRec = afl[i + 2].toInt() and 0xFF
+            for (rec in firstRec..lastRec) {
+                val cmd = byteArrayOf(
+                    0x00,
+                    0xB2.toByte(),                        // READ RECORD
+                    rec.toByte(),
+                    ((sfi shl 3) or 0x04).toByte(),       // P2: SFI<<3 | 0b100
+                    0x00
+                )
+                runCatching {
+                    val resp = transceiveWithGetResponse(dep, cmd)
+                    if (isSw9000(resp)) out.add(resp)
+                }
+            }
+            i += 4
+        }
+        return out
+    }
+
+    /**
+     * Sends an APDU and transparently follows up with GET RESPONSE / Le-retry
+     * if the card replies with 0x61xx (more data) or 0x6Cxx (wrong Le).
+     */
+    private fun transceiveWithGetResponse(dep: IsoDep, command: ByteArray): ByteArray {
+        var current = dep.transceive(command)
+        var guard = 0
+        while (current.size >= 2 && guard < 8) {
+            val sw1 = current[current.size - 2].toInt() and 0xFF
+            val sw2 = current[current.size - 1].toInt() and 0xFF
+            when (sw1) {
+                0x61 -> {
+                    // More data — issue GET RESPONSE to drain it, append data
+                    val getResp = byteArrayOf(0x00, 0xC0.toByte(), 0x00, 0x00, sw2.toByte())
+                    val next = dep.transceive(getResp)
+                    val merged = current.copyOf(current.size - 2) + next
+                    current = merged
+                }
+                0x6C -> {
+                    // Wrong Le — retry the previous command with the correct Le
+                    val retried = command.copyOf()
+                    retried[retried.size - 1] = sw2.toByte()
+                    current = dep.transceive(retried)
+                }
+                else -> return current
+            }
+            guard++
+        }
+        return current
+    }
+
+    /**
+     * Reads PDOL (tag 9F38) from the FCI response and returns a byte string of
+     * default values (zero-filled) sized per PDOL's TL pairs. If no PDOL is
+     * present, returns an empty array (caller sends 83 00).
+     */
+    private fun extractPdolDefault(fci: ByteArray): ByteArray {
+        val parsed = runCatching { parseTLVUseCase.execute(fci) }.getOrNull() ?: return ByteArray(0)
+        val pdolHex = parsed["PDOL"] ?: parsed["Tag 9F38"] ?: return ByteArray(0)
+        val pdol = hexToBytes(pdolHex)
+        val out = mutableListOf<Byte>()
+        var i = 0
+        while (i < pdol.size) {
+            // Skip tag (handle multi-byte: lower 5 bits all 1 means continuation)
+            val first = pdol[i].toInt() and 0xFF
+            i++
+            if ((first and 0x1F) == 0x1F) {
+                while (i < pdol.size) {
+                    val b = pdol[i].toInt() and 0xFF
+                    i++
+                    if ((b and 0x80) == 0) break
+                }
+            }
+            if (i >= pdol.size) break
+            val len = pdol[i].toInt() and 0xFF
+            i++
+            repeat(len) { out.add(0x00) }
+        }
+        return out.toByteArray()
     }
 
     private fun buildSelectCommand(aid: ByteArray): ByteArray =
@@ -103,4 +246,14 @@ class ProcessNfcIntentUseCase @Inject constructor(
         response.size >= 2
             && (response[response.size - 2].toInt() and 0xFF) == 0x90
             && (response[response.size - 1].toInt() and 0xFF) == 0x00
+
+    private fun describeStatusWord(response: ByteArray): String {
+        if (response.size < 2) return "no response"
+        val sw1 = response[response.size - 2].toInt() and 0xFF
+        val sw2 = response[response.size - 1].toInt() and 0xFF
+        return "SW=%02X%02X (%s)".format(sw1, sw2, NfcDataDecoder.decodeStatusWord(sw1, sw2))
+    }
+
+    private fun hexToBytes(hex: String): ByteArray =
+        hex.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
 }

--- a/app/src/main/java/io/github/romantsisyk/nfccardreader/presentation/navigation/NavGraph.kt
+++ b/app/src/main/java/io/github/romantsisyk/nfccardreader/presentation/navigation/NavGraph.kt
@@ -1,6 +1,9 @@
 package io.github.romantsisyk.nfccardreader.presentation.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -8,44 +11,41 @@ import io.github.romantsisyk.nfccardreader.presentation.ui.HistoryScreen
 import io.github.romantsisyk.nfccardreader.presentation.ui.NFCReaderScreen
 import io.github.romantsisyk.nfccardreader.presentation.viewmodel.NFCReaderViewModel
 
-/**
- * Navigation routes for the application.
- */
 object NavRoutes {
     const val READER = "reader"
     const val HISTORY = "history"
 }
 
-/**
- * Main navigation graph for the application.
- *
- * @param navController The navigation controller
- * @param viewModel The shared ViewModel
- */
 @Composable
-fun NfcNavGraph(
-    navController: NavHostController,
-    viewModel: NFCReaderViewModel
-) {
+fun NfcNavGraph(navController: NavHostController) {
+    val viewModel: NFCReaderViewModel = hiltViewModel()
+
     NavHost(
         navController = navController,
         startDestination = NavRoutes.READER
     ) {
         composable(NavRoutes.READER) {
+            val uiState by viewModel.uiState.collectAsState()
             NFCReaderScreen(
-                viewModel = viewModel,
+                uiState = uiState,
+                onClearData = viewModel::clearNfcData,
+                onSaveScan = viewModel::saveCurrentScan,
+                onDismissError = viewModel::dismissError,
                 onNavigateToHistory = {
-                    navController.navigate(NavRoutes.HISTORY)
+                    navController.navigate(NavRoutes.HISTORY) {
+                        launchSingleTop = true
+                    }
                 }
             )
         }
 
         composable(NavRoutes.HISTORY) {
+            val history by viewModel.scanHistory.collectAsState()
             HistoryScreen(
-                viewModel = viewModel,
-                onNavigateBack = {
-                    navController.popBackStack()
-                }
+                history = history,
+                onDelete = viewModel::deleteScan,
+                onClearAll = viewModel::clearHistory,
+                onNavigateBack = { navController.popBackStack() }
             )
         }
     }

--- a/app/src/main/java/io/github/romantsisyk/nfccardreader/presentation/ui/HistoryScreen.kt
+++ b/app/src/main/java/io/github/romantsisyk/nfccardreader/presentation/ui/HistoryScreen.kt
@@ -14,24 +14,19 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.romantsisyk.nfccardreader.domain.model.NFCData
-import io.github.romantsisyk.nfccardreader.presentation.viewmodel.NFCReaderViewModel
 import io.github.romantsisyk.nfccardreader.utils.orNA
 
-/**
- * Screen displaying scan history.
- *
- * @param viewModel The ViewModel containing scan history data
- * @param onNavigateBack Callback for navigation back action
- */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HistoryScreen(
-    viewModel: NFCReaderViewModel,
+    history: List<NFCData>,
+    onDelete: (Long) -> Unit,
+    onClearAll: () -> Unit,
     onNavigateBack: () -> Unit
 ) {
-    val history by viewModel.scanHistory.collectAsState()
     var showClearDialog by remember { mutableStateOf(false) }
 
     Scaffold(
@@ -51,7 +46,7 @@ fun HistoryScreen(
                         IconButton(onClick = { showClearDialog = true }) {
                             Icon(
                                 imageVector = Icons.Default.DeleteSweep,
-                                contentDescription = "Clear All"
+                                contentDescription = "Clear all scan history"
                             )
                         }
                     }
@@ -97,10 +92,10 @@ fun HistoryScreen(
             ) {
                 item { Spacer(modifier = Modifier.height(8.dp)) }
 
-                items(history) { scan ->
+                items(history, key = { it.dbId }) { scan ->
                     HistoryItem(
                         scan = scan,
-                        onDelete = { /* TODO: Add delete by ID */ }
+                        onDelete = { onDelete(scan.dbId) }
                     )
                 }
 
@@ -117,7 +112,7 @@ fun HistoryScreen(
             confirmButton = {
                 TextButton(
                     onClick = {
-                        viewModel.clearHistory()
+                        onClearAll()
                         showClearDialog = false
                     }
                 ) {
@@ -133,12 +128,6 @@ fun HistoryScreen(
     }
 }
 
-/**
- * Individual history item card.
- *
- * @param scan The NFC data for this history item
- * @param onDelete Callback for delete action
- */
 @Composable
 private fun HistoryItem(
     scan: NFCData,
@@ -180,7 +169,7 @@ private fun HistoryItem(
                     overflow = TextOverflow.Ellipsis
                 )
 
-                scan.parsedTlvData["Application PAN"]?.let { pan ->
+                scan.parsedTlvData["APPLICATION_PAN"]?.let { pan ->
                     Text(
                         text = pan,
                         style = MaterialTheme.typography.bodySmall,
@@ -199,13 +188,41 @@ private fun HistoryItem(
                 }
             }
 
-            IconButton(onClick = onDelete) {
+            IconButton(
+                onClick = onDelete,
+                modifier = Modifier.heightIn(min = 48.dp)
+            ) {
                 Icon(
                     imageVector = Icons.Default.Delete,
-                    contentDescription = "Delete",
+                    contentDescription = "Delete scan for ${scan.cardType.orNA()}",
                     tint = MaterialTheme.colorScheme.error
                 )
             }
         }
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun HistoryItemPreview() {
+    HistoryItem(
+        scan = NFCData(
+            dbId = 1,
+            cardType = "MasterCard Credit",
+            applicationLabel = "MasterCard",
+            transactionDate = "20.04.2023"
+        ),
+        onDelete = {}
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun HistoryScreenEmptyPreview() {
+    HistoryScreen(
+        history = emptyList(),
+        onDelete = {},
+        onClearAll = {},
+        onNavigateBack = {}
+    )
 }

--- a/app/src/main/java/io/github/romantsisyk/nfccardreader/presentation/ui/NFCReaderScreen.kt
+++ b/app/src/main/java/io/github/romantsisyk/nfccardreader/presentation/ui/NFCReaderScreen.kt
@@ -16,30 +16,27 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.github.romantsisyk.nfccardreader.R
-import io.github.romantsisyk.nfccardreader.presentation.viewmodel.NFCReaderViewModel
 import io.github.romantsisyk.nfccardreader.presentation.viewmodel.NfcUiState
 import io.github.romantsisyk.nfccardreader.utils.orNA
 
-/**
- * Main NFC Reader screen composable.
- *
- * @param viewModel The ViewModel containing NFC data and state
- * @param onNavigateToHistory Callback for navigating to history screen
- */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NFCReaderScreen(
-    viewModel: NFCReaderViewModel,
-    onNavigateToHistory: () -> Unit = {}
+    uiState: NfcUiState,
+    onClearData: () -> Unit,
+    onSaveScan: () -> Unit,
+    onDismissError: () -> Unit,
+    onNavigateToHistory: () -> Unit
 ) {
-    val uiState by viewModel.uiState.collectAsState()
-
-    // Section visibility states
-    var showRawResponse by remember { mutableStateOf(true) }
     var showParsedTlvData by remember { mutableStateOf(true) }
     var showBasicCardInfo by remember { mutableStateOf(true) }
     var showAdvancedCardInfo by remember { mutableStateOf(false) }
@@ -52,7 +49,7 @@ fun NFCReaderScreen(
                 title = { Text(stringResource(R.string.nfc_reader_card_information)) },
                 actions = {
                     IconButton(onClick = onNavigateToHistory) {
-                        Icon(Icons.Default.History, contentDescription = "History")
+                        Icon(Icons.Default.History, contentDescription = "View scan history")
                     }
                 }
             )
@@ -64,8 +61,7 @@ fun NFCReaderScreen(
                     .fillMaxSize()
                     .padding(padding)
             ) {
-                // NFC Status Banner
-                NfcStatusBanner(uiState)
+                NfcStatusBanner(uiState, onDismissError)
 
                 LazyColumn(
                     modifier = Modifier
@@ -73,33 +69,14 @@ fun NFCReaderScreen(
                         .padding(horizontal = 16.dp),
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    // Action Buttons
                     item {
                         ActionButtonsRow(
                             uiState = uiState,
-                            onClear = { viewModel.clearNfcData() },
-                            onLoadMock = { viewModel.processMockNfcIntent() },
-                            onSave = { viewModel.saveCurrentScan() }
+                            onClear = onClearData,
+                            onSave = onSaveScan
                         )
                     }
 
-                    // Raw NFC Response
-                    item {
-                        CollapsibleCard(
-                            title = stringResource(R.string.raw_nfc_response),
-                            icon = Icons.Default.Terminal,
-                            isExpanded = showRawResponse,
-                            onToggle = { showRawResponse = !showRawResponse }
-                        ) {
-                            Text(
-                                text = stringResource(R.string.raw_response, uiState.rawResponse),
-                                fontSize = 14.sp,
-                                modifier = Modifier.padding(top = 8.dp)
-                            )
-                        }
-                    }
-
-                    // Basic Card Information
                     item {
                         CollapsibleCard(
                             title = "Basic Card Information",
@@ -111,7 +88,6 @@ fun NFCReaderScreen(
                         }
                     }
 
-                    // Transaction Information
                     item {
                         CollapsibleCard(
                             title = "Transaction Information",
@@ -123,7 +99,6 @@ fun NFCReaderScreen(
                         }
                     }
 
-                    // Advanced Card Information
                     item {
                         CollapsibleCard(
                             title = "Advanced Card Information",
@@ -135,7 +110,6 @@ fun NFCReaderScreen(
                         }
                     }
 
-                    // Security Information
                     item {
                         CollapsibleCard(
                             title = "Security Information",
@@ -147,7 +121,6 @@ fun NFCReaderScreen(
                         }
                     }
 
-                    // Parsed TLV Data
                     item {
                         CollapsibleCard(
                             title = stringResource(R.string.parsed_tlv_data),
@@ -163,7 +136,6 @@ fun NFCReaderScreen(
                 }
             }
 
-            // Loading Overlay
             if (uiState.isLoading) {
                 LoadingOverlay()
             }
@@ -171,78 +143,74 @@ fun NFCReaderScreen(
     }
 }
 
-/**
- * NFC status banner showing current state.
- */
 @Composable
-private fun NfcStatusBanner(uiState: NfcUiState) {
-    val backgroundColor: Color
-    val text: String
-    val icon: ImageVector
+private fun NfcStatusBanner(uiState: NfcUiState, onDismissError: () -> Unit) {
+    val (backgroundColor, text, icon) = remember(uiState) {
+        when {
+            uiState.errorMessage != null -> Triple(
+                null as Color?, uiState.errorMessage, Icons.Default.Error
+            )
+            uiState.nfcAvailability?.isAvailable == false -> Triple(
+                null, "NFC not available on this device", Icons.Default.Warning
+            )
+            uiState.nfcAvailability?.isEnabled == false -> Triple(
+                null, "NFC is disabled. Please enable it in settings.", Icons.Default.Warning
+            )
+            uiState.lastScanSaved -> Triple(
+                null, "Scan saved to history", Icons.Default.Check
+            )
+            uiState.additionalInfo != null -> Triple(
+                null, "Card data read successfully", Icons.Default.CheckCircle
+            )
+            else -> Triple(null, "Ready to scan NFC card", Icons.Default.Nfc)
+        }
+    }
 
-    when {
-        uiState.errorMessage != null -> {
-            backgroundColor = MaterialTheme.colorScheme.errorContainer
-            text = uiState.errorMessage
-            icon = Icons.Default.Error
-        }
-        uiState.nfcAvailability?.isAvailable == false -> {
-            backgroundColor = MaterialTheme.colorScheme.errorContainer
-            text = "NFC not available on this device"
-            icon = Icons.Default.Warning
-        }
-        uiState.nfcAvailability?.isEnabled == false -> {
-            backgroundColor = Color(0xFFFFF3E0)
-            text = "NFC is disabled. Please enable it in settings."
-            icon = Icons.Default.Warning
-        }
-        uiState.lastScanSaved -> {
-            backgroundColor = MaterialTheme.colorScheme.primaryContainer
-            text = "Scan saved to history"
-            icon = Icons.Default.Check
-        }
-        uiState.additionalInfo != null -> {
-            backgroundColor = Color(0xFFE8F5E9)
-            text = "Card data read successfully"
-            icon = Icons.Default.CheckCircle
-        }
-        else -> {
-            backgroundColor = MaterialTheme.colorScheme.surfaceVariant
-            text = "Ready to scan NFC card"
-            icon = Icons.Default.Nfc
-        }
+    val resolvedBg = when {
+        uiState.errorMessage != null || uiState.nfcAvailability?.isAvailable == false ->
+            MaterialTheme.colorScheme.errorContainer
+        uiState.nfcAvailability?.isEnabled == false ->
+            MaterialTheme.colorScheme.tertiaryContainer
+        uiState.lastScanSaved ->
+            MaterialTheme.colorScheme.primaryContainer
+        uiState.additionalInfo != null ->
+            MaterialTheme.colorScheme.secondaryContainer
+        else ->
+            MaterialTheme.colorScheme.surfaceVariant
     }
 
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .background(backgroundColor)
+            .background(resolvedBg)
             .padding(12.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.Center
     ) {
         Icon(
             imageVector = icon,
-            contentDescription = null,
+            contentDescription = text,
             modifier = Modifier.size(20.dp)
         )
         Spacer(modifier = Modifier.width(8.dp))
         Text(
-            text = text,
-            fontSize = 14.sp,
-            fontWeight = FontWeight.Medium
+            text = text ?: "",
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Medium,
+            modifier = Modifier.weight(1f)
         )
+        if (uiState.errorMessage != null) {
+            IconButton(onClick = onDismissError) {
+                Icon(Icons.Default.Close, contentDescription = "Dismiss error")
+            }
+        }
     }
 }
 
-/**
- * Row of action buttons.
- */
 @Composable
 private fun ActionButtonsRow(
     uiState: NfcUiState,
     onClear: () -> Unit,
-    onLoadMock: () -> Unit,
     onSave: () -> Unit
 ) {
     Row(
@@ -253,7 +221,9 @@ private fun ActionButtonsRow(
     ) {
         OutlinedButton(
             onClick = onClear,
-            modifier = Modifier.weight(1f),
+            modifier = Modifier
+                .weight(1f)
+                .heightIn(min = 48.dp),
             shape = RoundedCornerShape(8.dp)
         ) {
             Icon(Icons.Default.Clear, contentDescription = null, modifier = Modifier.size(18.dp))
@@ -261,19 +231,11 @@ private fun ActionButtonsRow(
             Text("Clear")
         }
 
-        OutlinedButton(
-            onClick = onLoadMock,
-            modifier = Modifier.weight(1f),
-            shape = RoundedCornerShape(8.dp)
-        ) {
-            Icon(Icons.Default.Refresh, contentDescription = null, modifier = Modifier.size(18.dp))
-            Spacer(modifier = Modifier.width(4.dp))
-            Text("Mock")
-        }
-
         Button(
             onClick = onSave,
-            modifier = Modifier.weight(1f),
+            modifier = Modifier
+                .weight(1f)
+                .heightIn(min = 48.dp),
             enabled = uiState.additionalInfo != null && !uiState.lastScanSaved,
             shape = RoundedCornerShape(8.dp)
         ) {
@@ -284,9 +246,6 @@ private fun ActionButtonsRow(
     }
 }
 
-/**
- * Collapsible card component.
- */
 @Composable
 private fun CollapsibleCard(
     title: String,
@@ -295,6 +254,8 @@ private fun CollapsibleCard(
     onToggle: () -> Unit,
     content: @Composable () -> Unit
 ) {
+    val toggleDescription = if (isExpanded) "Collapse $title section" else "Expand $title section"
+
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -307,7 +268,11 @@ private fun CollapsibleCard(
                 modifier = Modifier
                     .fillMaxWidth()
                     .clip(RoundedCornerShape(8.dp))
-                    .clickable { onToggle() }
+                    .semantics {
+                        role = Role.Button
+                        stateDescription = toggleDescription
+                    }
+                    .clickable(onClickLabel = toggleDescription) { onToggle() }
                     .padding(vertical = 4.dp),
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
@@ -320,13 +285,13 @@ private fun CollapsibleCard(
                     )
                     Text(
                         text = title,
-                        fontSize = 16.sp,
+                        style = MaterialTheme.typography.titleSmall,
                         fontWeight = FontWeight.SemiBold
                     )
                 }
                 Icon(
                     imageVector = if (isExpanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
-                    contentDescription = "Toggle"
+                    contentDescription = toggleDescription
                 )
             }
 
@@ -343,38 +308,32 @@ private fun CollapsibleCard(
     }
 }
 
-/**
- * Basic card information content.
- */
 @Composable
 private fun BasicCardInfoContent(uiState: NfcUiState) {
     val info = uiState.additionalInfo
     val tlvData = uiState.nfcTagData
 
     if (info == null && tlvData.isEmpty()) {
-        Text("No card information available", fontSize = 14.sp, color = MaterialTheme.colorScheme.outline)
+        Text("No card information available", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.outline)
         return
     }
 
     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
         InfoRow("Card Type", info?.cardType.orNA())
-        tlvData["Cardholder Name"]?.let { InfoRow("Cardholder Name", it) }
-        tlvData["Application PAN"]?.let { InfoRow("Card Number", it) }
-        tlvData["Expiration Date"]?.let { InfoRow("Expiration Date", it) }
+        tlvData["CARDHOLDER_NAME"]?.let { InfoRow("Cardholder Name", it) }
+        tlvData["APPLICATION_PAN"]?.let { InfoRow("Card Number", it) }
+        tlvData["EXPIRATION_DATE"]?.let { InfoRow("Expiration Date", it) }
         InfoRow("Application Label", info?.applicationLabel.orNA())
-        tlvData["Application Preferred Name"]?.let { InfoRow("Preferred Name", it) }
+        tlvData["APPLICATION_PREFERRED_NAME"]?.let { InfoRow("Preferred Name", it) }
     }
 }
 
-/**
- * Transaction information content.
- */
 @Composable
 private fun TransactionInfoContent(uiState: NfcUiState) {
     val info = uiState.additionalInfo
 
     if (info == null) {
-        Text("No transaction information available", fontSize = 14.sp, color = MaterialTheme.colorScheme.outline)
+        Text("No transaction information available", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.outline)
         return
     }
 
@@ -388,15 +347,12 @@ private fun TransactionInfoContent(uiState: NfcUiState) {
     }
 }
 
-/**
- * Advanced card information content.
- */
 @Composable
 private fun AdvancedCardInfoContent(uiState: NfcUiState) {
     val info = uiState.additionalInfo
 
     if (info == null) {
-        Text("No advanced information available", fontSize = 14.sp, color = MaterialTheme.colorScheme.outline)
+        Text("No advanced information available", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.outline)
         return
     }
 
@@ -407,22 +363,18 @@ private fun AdvancedCardInfoContent(uiState: NfcUiState) {
         info.issuerCountryCode?.let { InfoRow("Issuer Country", it) }
         info.transactionCurrencyExponent?.let { InfoRow("Currency Exponent", it) }
         info.serviceCode?.let { InfoRow("Service Code", it) }
-        info.issuerUrl?.let { InfoRow("Issuer URL", it) }
         info.formFactorIndicator?.let { InfoRow("Form Factor", it) }
         info.terminalCountryCode?.let { InfoRow("Terminal Country", it) }
         info.applicationCurrencyCode?.let { InfoRow("App Currency", it) }
     }
 }
 
-/**
- * Security information content.
- */
 @Composable
 private fun SecurityInfoContent(uiState: NfcUiState) {
     val info = uiState.additionalInfo
 
     if (info == null) {
-        Text("No security information available", fontSize = 14.sp, color = MaterialTheme.colorScheme.outline)
+        Text("No security information available", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.outline)
         return
     }
 
@@ -437,15 +389,12 @@ private fun SecurityInfoContent(uiState: NfcUiState) {
     }
 }
 
-/**
- * Parsed TLV data content.
- */
 @Composable
 private fun ParsedTlvContent(uiState: NfcUiState) {
     val tlvData = uiState.nfcTagData
 
     if (tlvData.isEmpty()) {
-        Text(stringResource(R.string.no_tlv_data_available), fontSize = 14.sp, color = MaterialTheme.colorScheme.outline)
+        Text(stringResource(R.string.no_tlv_data_available), style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.outline)
         return
     }
 
@@ -456,9 +405,6 @@ private fun ParsedTlvContent(uiState: NfcUiState) {
     }
 }
 
-/**
- * Single row of information with label and value.
- */
 @Composable
 private fun InfoRow(label: String, value: String) {
     Row(
@@ -467,22 +413,19 @@ private fun InfoRow(label: String, value: String) {
     ) {
         Text(
             text = "$label:",
-            fontSize = 14.sp,
+            style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.weight(0.4f)
         )
         Text(
             text = value,
-            fontSize = 14.sp,
+            style = MaterialTheme.typography.bodyMedium,
             fontWeight = FontWeight.Medium,
             modifier = Modifier.weight(0.6f)
         )
     }
 }
 
-/**
- * Loading overlay with progress indicator.
- */
 @Composable
 private fun LoadingOverlay() {
     Box(
@@ -507,8 +450,14 @@ private fun LoadingOverlay() {
     }
 }
 
-// Legacy composable for backward compatibility
+@Preview(showBackground = true)
 @Composable
-fun NFCReaderUI(viewModel: NFCReaderViewModel) {
-    NFCReaderScreen(viewModel = viewModel)
+private fun NFCReaderScreenIdlePreview() {
+    NFCReaderScreen(
+        uiState = NfcUiState(),
+        onClearData = {},
+        onSaveScan = {},
+        onDismissError = {},
+        onNavigateToHistory = {}
+    )
 }

--- a/app/src/main/java/io/github/romantsisyk/nfccardreader/presentation/ui/theme/Color.kt
+++ b/app/src/main/java/io/github/romantsisyk/nfccardreader/presentation/ui/theme/Color.kt
@@ -2,6 +2,7 @@ package io.github.romantsisyk.nfccardreader.presentation.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
+// Brand palette
 val Purple80 = Color(0xFFD0BCFF)
 val PurpleGrey80 = Color(0xFFCCC2DC)
 val Pink80 = Color(0xFFEFB8C8)
@@ -9,3 +10,11 @@ val Pink80 = Color(0xFFEFB8C8)
 val Purple40 = Color(0xFF6650a4)
 val PurpleGrey40 = Color(0xFF625b71)
 val Pink40 = Color(0xFF7D5260)
+
+// NFC app semantic tokens — use these instead of hardcoded hex values
+val NfcSuccess = Color(0xFF2E7D32)
+val NfcSuccessContainer = Color(0xFFC8E6C9)
+val NfcWarning = Color(0xFFE65100)
+val NfcWarningContainer = Color(0xFFFFE0B2)
+val NfcActive = Color(0xFF0277BD)
+val NfcActiveContainer = Color(0xFFB3E5FC)

--- a/app/src/main/java/io/github/romantsisyk/nfccardreader/presentation/viewmodel/NFCViewModel.kt
+++ b/app/src/main/java/io/github/romantsisyk/nfccardreader/presentation/viewmodel/NFCViewModel.kt
@@ -13,16 +13,13 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-/**
- * UI state for the NFC Reader screen.
- */
 data class NfcUiState(
     val isLoading: Boolean = false,
     val nfcTagData: Map<String, String> = emptyMap(),
-    val rawResponse: String = "Empty NFC Response",
     val additionalInfo: NFCData? = null,
     val error: NfcError? = null,
     val errorMessage: String? = null,
@@ -30,13 +27,6 @@ data class NfcUiState(
     val lastScanSaved: Boolean = false
 )
 
-/**
- * ViewModel for NFC Reader functionality.
- *
- * Manages UI state and coordinates between the UI layer and repository.
- *
- * @property repository Repository for NFC operations and data persistence
- */
 @HiltViewModel
 class NFCReaderViewModel @Inject constructor(
     private val repository: NfcRepository
@@ -45,209 +35,94 @@ class NFCReaderViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(NfcUiState())
     val uiState: StateFlow<NfcUiState> = _uiState
 
-    // Legacy state flows for backward compatibility
-    val nfcTagData: StateFlow<Map<String, String>>
-        get() = MutableStateFlow(_uiState.value.nfcTagData)
-
-    val rawResponse: StateFlow<String>
-        get() = MutableStateFlow(_uiState.value.rawResponse)
-
-    val error: StateFlow<String?>
-        get() = MutableStateFlow(_uiState.value.errorMessage)
-
-    val additionalInfo: StateFlow<NFCData?>
-        get() = MutableStateFlow(_uiState.value.additionalInfo)
-
-    /**
-     * Flow of scan history from the database.
-     */
     val scanHistory = repository.getScanHistory()
-        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     init {
         checkNfcAvailability()
     }
 
-    /**
-     * Checks NFC availability on the device.
-     */
     fun checkNfcAvailability() {
         when (val result = repository.checkNfcAvailability()) {
-            is NfcResult.Success -> {
-                _uiState.value = _uiState.value.copy(nfcAvailability = result.data)
+            is NfcResult.Success -> _uiState.update { it.copy(nfcAvailability = result.data) }
+            is NfcResult.Error -> _uiState.update {
+                it.copy(error = result.error, errorMessage = result.message)
             }
-            is NfcResult.Error -> {
-                _uiState.value = _uiState.value.copy(
-                    error = result.error,
-                    errorMessage = result.message
-                )
-            }
-            is NfcResult.Loading -> { /* Not expected here */ }
+            is NfcResult.Loading -> Unit
         }
     }
 
-    /**
-     * Processes an NFC intent and updates UI state.
-     *
-     * @param intent The NFC intent to process
-     */
     fun processNfcIntent(intent: Intent) {
         viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(isLoading = true, error = null, errorMessage = null)
+            _uiState.update { it.copy(isLoading = true, error = null, errorMessage = null) }
 
             when (val result = repository.processNfcIntent(intent)) {
                 is NfcResult.Success -> {
                     val data = result.data
-                    _uiState.value = _uiState.value.copy(
-                        isLoading = false,
-                        nfcTagData = data.parsedTlvData,
-                        rawResponse = data.rawResponse,
-                        additionalInfo = data,
-                        error = null,
-                        errorMessage = null,
-                        lastScanSaved = false
-                    )
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            nfcTagData = data.parsedTlvData,
+                            additionalInfo = data,
+                            error = null,
+                            errorMessage = null,
+                            lastScanSaved = false
+                        )
+                    }
                 }
-                is NfcResult.Error -> {
-                    _uiState.value = _uiState.value.copy(
-                        isLoading = false,
-                        error = result.error,
-                        errorMessage = result.message
-                    )
+                is NfcResult.Error -> _uiState.update {
+                    it.copy(isLoading = false, error = result.error, errorMessage = result.message)
                 }
-                is NfcResult.Loading -> {
-                    _uiState.value = _uiState.value.copy(isLoading = true)
-                }
+                is NfcResult.Loading -> _uiState.update { it.copy(isLoading = true) }
             }
         }
     }
 
-    /**
-     * Saves the current scan to history.
-     */
     fun saveCurrentScan() {
         val currentData = _uiState.value.additionalInfo ?: return
 
         viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(isLoading = true)
+            _uiState.update { it.copy(isLoading = true) }
 
             when (val result = repository.saveScanRecord(currentData)) {
-                is NfcResult.Success -> {
-                    _uiState.value = _uiState.value.copy(
-                        isLoading = false,
-                        lastScanSaved = true
-                    )
+                is NfcResult.Success -> _uiState.update {
+                    it.copy(isLoading = false, lastScanSaved = true)
                 }
-                is NfcResult.Error -> {
-                    _uiState.value = _uiState.value.copy(
-                        isLoading = false,
-                        error = result.error,
-                        errorMessage = result.message
-                    )
+                is NfcResult.Error -> _uiState.update {
+                    it.copy(isLoading = false, error = result.error, errorMessage = result.message)
                 }
-                is NfcResult.Loading -> { /* Not expected here */ }
+                is NfcResult.Loading -> Unit
             }
         }
     }
 
-    /**
-     * Deletes a scan record from history.
-     *
-     * @param id The ID of the scan to delete
-     */
     fun deleteScan(id: Long) {
         viewModelScope.launch {
-            repository.deleteScan(id)
+            when (val result = repository.deleteScan(id)) {
+                is NfcResult.Error -> _uiState.update {
+                    it.copy(error = result.error, errorMessage = result.message)
+                }
+                else -> Unit
+            }
         }
     }
 
-    /**
-     * Clears all scan history.
-     */
     fun clearHistory() {
         viewModelScope.launch {
-            repository.clearHistory()
+            when (val result = repository.clearHistory()) {
+                is NfcResult.Error -> _uiState.update {
+                    it.copy(error = result.error, errorMessage = result.message)
+                }
+                else -> Unit
+            }
         }
     }
 
-    /**
-     * Clears the current NFC data and resets UI state.
-     */
     fun clearNfcData() {
-        _uiState.value = NfcUiState(nfcAvailability = _uiState.value.nfcAvailability)
+        _uiState.update { NfcUiState(nfcAvailability = it.nfcAvailability) }
     }
 
-    /**
-     * Loads mock NFC data for testing purposes.
-     */
-    fun processMockNfcIntent() {
-        viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(isLoading = true)
-
-            val mockData = NFCData(
-                rawResponse = "6F 37 84 0E 325041592E5359532E4444463031 A5 25 88 01 02 5F 2D 02 656E " +
-                        "9F 11 01 01 50 0A 4D617374657243617264 87 01 01 9F 38 06 9F1A029505 " +
-                        "5F 20 0F 4A4F484E20512E2050554254494320 5A 0B 5412345678901234 5F 24 03 250228 " +
-                        "5F 30 02 0201 9F 0D 05 B0600000 9F 0E 05 0010000000 9F 0F 05 B0604000 " +
-                        "9F 12 0A 4D6173746572436172 57 13 5412345678901234D250228753622340 " +
-                        "5F 28 02 0840 9F 1C 08 30303030303132 9F 1E 08 3132333435363738 " +
-                        "9F 36 02 0003 82 02 1980 95 05 0080008000 9C 01 00 " +
-                        "9F 02 06 000000002500 5F 2A 02 0840 9A 03 230420 9F 21 03 103542 " +
-                        "9F 26 08 A1B2C3D4E5F6789A 9F 27 01 80 9F 34 03 1E0305 9F 37 04 FE9A8B21 " +
-                        "9F 10 12 0110A00003220000000000000000000F 9F 6E 04 04210103 90 00",
-                parsedTlvData = mapOf(
-                    "Cardholder Name" to "JOHN Q. PUBLIC",
-                    "Application PAN" to "XXXX XXXX XXXX 1234",
-                    "Track2 Equivalent Data" to "XXXX...XXXX",
-                    "Expiration Date" to "02/25",
-                    "Application Preferred Name" to "MasterCard",
-                    "Service Code" to "201",
-                    "Issuer Country Code" to "USA",
-                    "Dedicated File Name" to "2PAY.SYS.DDF01",
-                    "Application Cryptogram" to "A1B2C3D4E5F6789A",
-                    "Terminal Verification Results" to "0080008000",
-                    "Application Transaction Counter" to "0003",
-                    "Interface Device Serial Number" to "12345678",
-                    "Terminal ID" to "00000012",
-                    "Application Interchange Profile" to "1980",
-                    "Issuer Application Data" to "0110A00003220000000000000000000F",
-                    "Form Factor Indicator" to "04210103",
-                    "Language Preference" to "en",
-                    "Unpredictable Number" to "FE9A8B21"
-                ),
-                cardType = "MasterCard Credit",
-                applicationLabel = "MasterCard",
-                transactionAmount = "25.00",
-                currencyCode = "USD",
-                transactionDate = "20.04.2023",
-                transactionStatus = "Successful",
-                applicationIdentifier = "MasterCard",
-                dedicatedFileName = "2PAY.SYS.DDF01",
-                issuerCountryCode = "USA",
-                serviceCode = "International interchange, By issuer, No restrictions",
-                formFactorIndicator = "Physical card with contact chip and contactless",
-                applicationTemplate = "A5 25 88 01 02 5F 2D 02 656E 9F 11 01 01",
-                unpredictableNumber = "FE9A8B21",
-                cardholderVerificationMethodResults = "Online PIN verified",
-                applicationCryptogram = "A1B2C3D4E5F6789A",
-                applicationTransactionCounter = "0003",
-                applicationInterchangeProfile = "1980",
-                terminalVerificationResults = "0080008000",
-                transactionType = "Purchase",
-                issuerApplicationData = "0110A00003220000000000000000000F",
-                terminalCountryCode = "USA",
-                interfaceDeviceSerialNumber = "12345678"
-            )
-
-            _uiState.value = _uiState.value.copy(
-                isLoading = false,
-                nfcTagData = mockData.parsedTlvData,
-                rawResponse = mockData.rawResponse,
-                additionalInfo = mockData,
-                error = null,
-                errorMessage = null,
-                lastScanSaved = false
-            )
-        }
+    fun dismissError() {
+        _uiState.update { it.copy(error = null, errorMessage = null) }
     }
 }

--- a/app/src/main/java/io/github/romantsisyk/nfccardreader/presentation/viewmodel/NFCViewModel.kt
+++ b/app/src/main/java/io/github/romantsisyk/nfccardreader/presentation/viewmodel/NFCViewModel.kt
@@ -99,10 +99,11 @@ class NFCReaderViewModel @Inject constructor(
     fun deleteScan(id: Long) {
         viewModelScope.launch {
             when (val result = repository.deleteScan(id)) {
+                is NfcResult.Success -> Unit
                 is NfcResult.Error -> _uiState.update {
                     it.copy(error = result.error, errorMessage = result.message)
                 }
-                else -> Unit
+                is NfcResult.Loading -> Unit
             }
         }
     }
@@ -110,10 +111,11 @@ class NFCReaderViewModel @Inject constructor(
     fun clearHistory() {
         viewModelScope.launch {
             when (val result = repository.clearHistory()) {
+                is NfcResult.Success -> Unit
                 is NfcResult.Error -> _uiState.update {
                     it.copy(error = result.error, errorMessage = result.message)
                 }
-                else -> Unit
+                is NfcResult.Loading -> Unit
             }
         }
     }

--- a/app/src/main/java/io/github/romantsisyk/nfccardreader/utils/NfcDataDecoder.kt
+++ b/app/src/main/java/io/github/romantsisyk/nfccardreader/utils/NfcDataDecoder.kt
@@ -1,6 +1,7 @@
 package io.github.romantsisyk.nfccardreader.utils
 
 import java.math.BigInteger
+import java.util.Calendar
 import java.util.Currency
 import java.util.Locale
 
@@ -67,6 +68,14 @@ object NfcDataDecoder {
         }
     }
 
+    /**
+     * Decodes an EMV BCD-encoded YYMMDD date.
+     * EMV Book 3 §4.3 defines tag 9A as a 3-byte numeric (n6) BCD field — the
+     * standard does not encode the century. Per EMV CA convention, the century
+     * is inferred relative to the current date: a year more than ~50 years
+     * ahead is treated as 19xx, otherwise 20xx. This avoids the hard "20YY"
+     * assumption and keeps working past the year 2100.
+     */
     fun decodeDate(bytes: List<String>): String {
         if (bytes.size < 3) return "Invalid Date"
         val (yy, mm, dd) = Triple(bytes[0], bytes[1], bytes[2])
@@ -74,7 +83,15 @@ object NfcDataDecoder {
         if (!yy.isBcdPair() || !mm.isBcdPair() || !dd.isBcdPair()) return "Invalid Date"
         val month = mm.toInt(); val day = dd.toInt()
         if (month !in 1..12 || day !in 1..31) return "Invalid Date"
-        return "$dd.$mm.20$yy"
+
+        val yearTwoDigit = yy.toInt()
+        val currentYear = Calendar.getInstance().get(Calendar.YEAR)
+        val currentCentury = (currentYear / 100) * 100
+        val currentYy = currentYear % 100
+        // Treat dates >50 years in the future as previous century (legacy data).
+        val century = if (yearTwoDigit - currentYy > 50) currentCentury - 100 else currentCentury
+        val fullYear = century + yearTwoDigit
+        return "$dd.$mm.$fullYear"
     }
 
     fun decodeTime(bytes: List<String>): String {
@@ -180,6 +197,57 @@ object NfcDataDecoder {
             "41" -> "Physical card hosted a virtual card"
             "42" -> "Mobile phone hosted a virtual card"
             else -> "Unknown form factor"
+        }
+    }
+
+    /**
+     * Decodes an APDU SW1/SW2 status word (ISO/IEC 7816-4 + EMV Book 1 §9).
+     * Returns a human-readable description for common cases or a hex fallback.
+     */
+    fun decodeStatusWord(sw1: Int, sw2: Int): String {
+        val sw = ((sw1 and 0xFF) shl 8) or (sw2 and 0xFF)
+        return when (sw) {
+            0x9000 -> "Success"
+            0x6200 -> "Warning: state of non-volatile memory unchanged"
+            0x6281 -> "Returned data may be corrupted"
+            0x6282 -> "End of file/record reached before reading Le bytes"
+            0x6283 -> "Selected file invalidated"
+            0x6284 -> "FCI not formatted to ISO 7816-4"
+            0x6300 -> "Authentication failed"
+            0x6700 -> "Wrong length"
+            0x6800 -> "Functions in CLA not supported"
+            0x6881 -> "Logical channel not supported"
+            0x6882 -> "Secure messaging not supported"
+            0x6900 -> "Command not allowed"
+            0x6981 -> "Command incompatible with file structure"
+            0x6982 -> "Security status not satisfied"
+            0x6983 -> "Authentication method blocked"
+            0x6984 -> "Referenced data invalidated"
+            0x6985 -> "Conditions of use not satisfied"
+            0x6986 -> "Command not allowed (no current EF)"
+            0x6987 -> "Expected SM data objects missing"
+            0x6988 -> "SM data objects incorrect"
+            0x6A00 -> "Wrong parameters P1-P2"
+            0x6A80 -> "Incorrect parameters in data field"
+            0x6A81 -> "Function not supported"
+            0x6A82 -> "File not found"
+            0x6A83 -> "Record not found"
+            0x6A84 -> "Not enough memory space in file"
+            0x6A85 -> "Lc inconsistent with TLV structure"
+            0x6A86 -> "Incorrect parameters P1-P2"
+            0x6A87 -> "Lc inconsistent with P1-P2"
+            0x6A88 -> "Referenced data not found"
+            0x6B00 -> "Wrong parameters P1-P2"
+            0x6D00 -> "Instruction code not supported or invalid"
+            0x6E00 -> "Class not supported"
+            0x6F00 -> "No precise diagnosis"
+            else -> when {
+                sw1 == 0x61 -> "More data available (${sw and 0xFF} bytes) — issue GET RESPONSE"
+                sw1 == 0x6C -> "Wrong Le; correct Le=${sw and 0xFF}"
+                sw1 == 0x62 -> "Warning (state unchanged)"
+                sw1 == 0x63 -> "Warning (state changed); counter=${sw2 and 0x0F}"
+                else -> "Unknown status word (%04X)".format(sw)
+            }
         }
     }
 

--- a/app/src/main/java/io/github/romantsisyk/nfccardreader/utils/NfcDataDecoder.kt
+++ b/app/src/main/java/io/github/romantsisyk/nfccardreader/utils/NfcDataDecoder.kt
@@ -1,36 +1,20 @@
 package io.github.romantsisyk.nfccardreader.utils
 
+import java.math.BigInteger
 import java.util.Currency
 import java.util.Locale
-import java.math.BigInteger
 
-/**
- * Utility object for decoding NFC/EMV data values.
- *
- * Provides methods to convert raw hex byte values from EMV tags into
- * human-readable formats. Supports decoding of amounts, currencies,
- * dates, service codes, and various card-specific data.
- *
- * All methods handle invalid input gracefully, returning sensible
- * defaults or descriptive error strings rather than throwing exceptions.
- */
 object NfcDataDecoder {
 
-    /** ISO 4217 currency code mappings (numeric to alpha) */
+    // ISO 4217 numeric (BCD 4-char) → alpha-3 currency code
     private val currencyCodes = mapOf(
-        "0840" to "USD",
-        "0978" to "EUR",
-        "0980" to "UAH",
-        "0826" to "GBP",
-        "0392" to "JPY",
-        "0124" to "CAD",
-        "0036" to "AUD",
-        "0756" to "CHF",
-        "0156" to "CNY",
-        "0643" to "RUB"
+        "0840" to "USD", "0978" to "EUR", "0980" to "UAH", "0826" to "GBP",
+        "0392" to "JPY", "0124" to "CAD", "0036" to "AUD", "0756" to "CHF",
+        "0156" to "CNY", "0643" to "RUB", "0356" to "INR", "0410" to "KRW",
+        "0702" to "SGD", "0344" to "HKD", "0554" to "NZD", "0710" to "ZAR",
+        "0792" to "TRY", "0784" to "AED", "0682" to "SAR", "0376" to "ILS"
     )
-    
-    // Карта для типів транзакцій
+
     private val transactionTypes = mapOf(
         "00" to "Purchase",
         "01" to "Cash Advance",
@@ -41,89 +25,102 @@ object NfcDataDecoder {
         "50" to "Quasi-Cash",
         "90" to "Authorization Only"
     )
-    
-    /**
-     * Decodes a transaction amount from BCD-encoded hex bytes.
-     *
-     * @param bytes List of hex string bytes representing the amount
-     * @return Formatted decimal amount string (e.g., "123.45")
-     */
+
+    // ISO 3166-1 numeric (decimal) → alpha-2 country code
+    // Country codes are BCD-encoded in EMV; strip leading zeros to get the decimal key.
+    private val iso3166NumericToAlpha2 = mapOf(
+        "840" to "US", "980" to "UA", "826" to "GB", "392" to "JP",
+        "124" to "CA", "36"  to "AU", "756" to "CH", "156" to "CN",
+        "643" to "RU", "276" to "DE", "250" to "FR", "380" to "IT",
+        "724" to "ES", "616" to "PL", "203" to "CZ", "348" to "HU",
+        "642" to "RO", "703" to "SK", "191" to "HR", "578" to "NO",
+        "752" to "SE", "208" to "DK", "246" to "FI", "372" to "IE",
+        "528" to "NL", "56"  to "BE", "76"  to "BR", "356" to "IN",
+        "410" to "KR", "702" to "SG", "344" to "HK", "554" to "NZ",
+        "710" to "ZA", "792" to "TR", "682" to "SA", "784" to "AE",
+        "376" to "IL", "484" to "MX", "32"  to "AR", "152" to "CL",
+        "170" to "CO", "604" to "PE", "858" to "UY"
+    )
+
     fun decodeAmount(bytes: List<String>): String {
-        try {
+        if (bytes.isEmpty()) return "0.00"
+        return try {
             val joinedHex = bytes.joinToString("")
             val amount = BigInteger(joinedHex, 16).toLong() / 100.0
-            return String.format(Locale.US, "%.2f", amount)
-        } catch (e: Exception) {
-            return "0.00"
+            String.format(Locale.US, "%.2f", amount)
+        } catch (e: NumberFormatException) {
+            "0.00"
         }
     }
 
     fun decodeCurrency(bytes: List<String>): String {
-        val hexValue = bytes.joinToString("")
-        return currencyCodes[hexValue] ?: try {
-            val numericCode = hexValue.toInt(16)
-            val currencies = Currency.getAvailableCurrencies()
-            val currency = currencies.find { it.numericCode == numericCode }
-            currency?.currencyCode ?: "Unknown Currency ($hexValue)"
+        val bcdKey = bytes.joinToString("")  // e.g. "0840"
+        currencyCodes[bcdKey]?.let { return it }
+        // Fallback: interpret BCD as decimal numeric code
+        return try {
+            val numericCode = bcdKey.trimStart('0').ifEmpty { "0" }.toInt()
+            Currency.getAvailableCurrencies()
+                .find { it.numericCode == numericCode }
+                ?.currencyCode ?: "Unknown Currency ($bcdKey)"
         } catch (e: Exception) {
-            "Unknown Currency ($hexValue)"
+            "Unknown Currency ($bcdKey)"
         }
     }
 
     fun decodeDate(bytes: List<String>): String {
-        val year = "20${bytes[0]}"
-        val month = bytes[1]
-        val day = bytes[2]
-        return "$day.$month.$year"
+        if (bytes.size < 3) return "Invalid Date"
+        val (yy, mm, dd) = Triple(bytes[0], bytes[1], bytes[2])
+        // Validate BCD: each component must be two decimal digits
+        if (!yy.isBcdPair() || !mm.isBcdPair() || !dd.isBcdPair()) return "Invalid Date"
+        val month = mm.toInt(); val day = dd.toInt()
+        if (month !in 1..12 || day !in 1..31) return "Invalid Date"
+        return "$dd.$mm.20$yy"
     }
-    
+
     fun decodeTime(bytes: List<String>): String {
-        val hour = bytes[0]
-        val minute = bytes[1]
-        val second = bytes[2]
-        return "$hour:$minute:$second"
+        if (bytes.size < 3) return "Invalid Time"
+        val (hh, min, sec) = Triple(bytes[0], bytes[1], bytes[2])
+        if (!hh.isBcdPair() || !min.isBcdPair() || !sec.isBcdPair()) return "Invalid Time"
+        val h = hh.toInt(); val m = min.toInt(); val s = sec.toInt()
+        if (h > 23 || m > 59 || s > 59) return "Invalid Time"
+        return "$hh:$min:$sec"
     }
-    
+
+    /**
+     * Decodes a BCD-encoded ISO 3166-1 numeric country code.
+     * Bytes contain packed BCD digits (e.g., 08 40 → "0840" → "840" → "US").
+     */
     fun decodeCountryCode(bytes: List<String>): String {
-        val hexValue = bytes.joinToString("")
-        val numericCode = hexValue.toInt(16)
-        return try {
-            val availableLocales = Locale.getAvailableLocales()
-            val locale = availableLocales.find { 
-                it.country.isNotEmpty() && it.country.hashCode() == numericCode
-            }
-            locale?.displayCountry ?: "Unknown Country ($hexValue)"
-        } catch (e: Exception) {
-            "Unknown Country ($hexValue)"
-        }
+        val bcdCode = bytes.joinToString("").trimStart('0').ifEmpty { "0" }
+        return iso3166NumericToAlpha2[bcdCode]
+            ?.let { alpha2 -> Locale("", alpha2).displayCountry }
+            ?: "Unknown Country ($bcdCode)"
     }
-    
-    fun decodeTransactionType(byte: String): String {
-        return transactionTypes[byte] ?: "Unknown Transaction Type ($byte)"
-    }
-    
+
+    fun decodeTransactionType(byte: String): String =
+        transactionTypes[byte] ?: "Unknown Transaction Type ($byte)"
+
     fun decodeApplicationIdentifier(bytes: List<String>): String {
-        val hexValue = bytes.joinToString("")
+        val hex = bytes.joinToString("")
         return when {
-            hexValue.startsWith("A000000003") -> "Visa"
-            hexValue.startsWith("A000000004") -> "MasterCard"
-            hexValue.startsWith("A000000025") -> "American Express"
-            hexValue.startsWith("A000000065") -> "JCB"
-            hexValue.startsWith("A000000152") -> "Discover/Diners Club"
-            hexValue.startsWith("A000000324") -> "UnionPay"
-            hexValue.startsWith("A000000677") -> "Mir"
-            hexValue.contains("D276000025") -> "Interac"
-            else -> "Unknown Card ($hexValue)"
+            hex.startsWith("A000000003") -> "Visa"
+            hex.startsWith("A000000004") -> "Mastercard"
+            hex.startsWith("A000000025") -> "American Express"
+            hex.startsWith("A000000065") -> "JCB"
+            hex.startsWith("A000000152") -> "Discover/Diners Club"
+            hex.startsWith("A000000324") -> "UnionPay"
+            hex.startsWith("A000000677") -> "Mir"
+            hex.contains("D276000025")   -> "Interac"
+            else -> "Unknown Card ($hex)"
         }
     }
-    
+
     fun decodeServiceCode(bytes: List<String>): String {
-        val serviceCode = bytes.joinToString("")
-        val firstDigit = serviceCode.substring(0, 1)
-        val secondDigit = serviceCode.substring(1, 2)
-        val thirdDigit = serviceCode.substring(2, 3)
-        
-        val interchange = when (firstDigit) {
+        if (bytes.size < 3) return "Incomplete Service Code"
+        val code = bytes.joinToString("")
+        if (code.length < 3) return "Incomplete Service Code"
+
+        val interchange = when (code[0].toString()) {
             "1" -> "International interchange"
             "2" -> "International interchange, with IC"
             "5" -> "National interchange only"
@@ -132,15 +129,13 @@ object NfcDataDecoder {
             "9" -> "Test"
             else -> "Unknown interchange"
         }
-        
-        val authorization = when (secondDigit) {
+        val authorization = when (code[1].toString()) {
             "0" -> "Normal authorization"
             "2" -> "By issuer"
             "4" -> "By issuer unless explicit agreement"
             else -> "Unknown authorization"
         }
-        
-        val services = when (thirdDigit) {
+        val services = when (code[2].toString()) {
             "0" -> "No restrictions, PIN required"
             "1" -> "No restrictions"
             "2" -> "Goods and services only"
@@ -151,14 +146,11 @@ object NfcDataDecoder {
             "7" -> "Goods and services only, use PIN if feasible"
             else -> "Unknown services"
         }
-        
         return "$interchange, $authorization, $services"
     }
-    
+
     fun decodeCardholderVerificationMethodResult(bytes: List<String>): String {
-        val hexValue = bytes.joinToString("")
-        
-        return when (hexValue) {
+        return when (bytes.joinToString("")) {
             "0000" -> "No CVM performed"
             "0001" -> "Plaintext PIN verified by ICC"
             "0002" -> "Enciphered PIN verified online"
@@ -168,16 +160,13 @@ object NfcDataDecoder {
             "0006" -> "Signature"
             "0007" -> "No CVM required"
             "0008" -> "Card CVM reference check failed"
-            else -> "Unknown CVM ($hexValue)"
+            else   -> "Unknown CVM (${bytes.joinToString("")})"
         }
     }
-    
+
     fun decodeFormFactorIndicator(bytes: List<String>): String {
-        val hexValue = bytes.joinToString("")
-        val firstByte = if (hexValue.length >= 2) hexValue.substring(0, 2) else "00"
-        
-        val formFactor = when (firstByte) {
-            "00" -> "Unknown form factor"
+        val code = bytes.firstOrNull()?.take(2) ?: return "Unknown form factor"
+        return when (code) {
             "01" -> "Physical card with magnetic stripe"
             "02" -> "Physical card with magnetic stripe and contact chip"
             "03" -> "Physical card with contact chip only"
@@ -192,7 +181,8 @@ object NfcDataDecoder {
             "42" -> "Mobile phone hosted a virtual card"
             else -> "Unknown form factor"
         }
-        
-        return formFactor
     }
+
+    /** Returns true if the hex string is exactly 2 chars of decimal digits (valid BCD byte). */
+    private fun String.isBcdPair(): Boolean = length == 2 && all { it.isDigit() }
 }

--- a/app/src/main/java/io/github/romantsisyk/nfccardreader/utils/NfcDataMasker.kt
+++ b/app/src/main/java/io/github/romantsisyk/nfccardreader/utils/NfcDataMasker.kt
@@ -1,22 +1,28 @@
 package io.github.romantsisyk.nfccardreader.utils
 
 object NfcDataMasker {
+
+    /**
+     * Masks a PAN leaving only the last 4 digits visible.
+     * Handles EMV BCD-encoded PANs where shorter card numbers are padded
+     * with a trailing 'F' nibble (e.g., 15-digit Amex: "378282246310005F").
+     */
     fun maskPan(pan: String): String {
         if (pan.isEmpty()) return ""
-        return pan.replace(Regex("\\d(?=\\d{4})"), "X")
+        // Strip BCD padding nibble before masking so the regex sees only digits
+        val digits = pan.trimEnd('F', 'f')
+        if (digits.length < 4) return pan
+        return digits.replace(Regex("\\d(?=\\d{4})"), "X")
     }
 
+    /**
+     * Masks Track 2 data, hiding all but the last 4 digits of the PAN portion
+     * and obscuring the field separator.
+     */
     fun maskTrack2Data(track2: String): String {
         if (track2.isEmpty()) return ""
-        
-        // First mask digits in the PAN part
-        val maskedDigits = track2.replace(Regex("\\d(?=\\d{4})"), "X")
-        
-        // Then safely replace equals sign if it exists
-        return if (maskedDigits.contains("=")) {
-            maskedDigits.replace("=", "X")
-        } else {
-            maskedDigits
-        }
+        val digits = track2.trimEnd('F', 'f')
+        val masked = digits.replace(Regex("\\d(?=\\d{4})"), "X")
+        return if (masked.contains('=')) masked.replace('=', 'X') else masked
     }
 }

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Auto Backup rules (Android 6.0–11). Even though android:allowBackup="false"
+  short-circuits backup at the framework level, we declare an explicit
+  exclude-all policy in defense-in-depth: any future flip of allowBackup will
+  still leave card data out of cloud backups.
+-->
+<full-backup-content>
+    <exclude domain="database" path="." />
+    <exclude domain="sharedpref" path="." />
+    <exclude domain="file" path="." />
+    <exclude domain="external" path="." />
+    <exclude domain="root" path="." />
+</full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Data extraction rules (Android 12+, API 31+). Excludes all app data from both
+  cloud backup and device-to-device transfer. PCI-DSS: card-derived TLV data
+  must not leave the device.
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="external" path="." />
+        <exclude domain="root" path="." />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="external" path="." />
+        <exclude domain="root" path="." />
+    </device-transfer>
+</data-extraction-rules>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
+    <!--
+        Base config: HTTPS-only, system CAs only (no user-installed CAs to mitigate
+        MITM via rogue trust anchors). Debug overrides are deliberately omitted
+        so debug builds inherit the same strict policy.
+    -->
     <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />

--- a/app/src/test/java/io/github/romantsisyk/nfccardreader/data/repository/NfcRepositoryImplTest.kt
+++ b/app/src/test/java/io/github/romantsisyk/nfccardreader/data/repository/NfcRepositoryImplTest.kt
@@ -1,0 +1,99 @@
+package io.github.romantsisyk.nfccardreader.data.repository
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Verifies that NfcRepositoryImpl never serialises sensitive EMV tags into
+ * the JSON blob persisted to Room. We invoke the private `serializeTlvMap`
+ * via reflection so we can exercise the filtering logic without spinning up
+ * a Hilt graph or a real Room database. Robolectric is required so that
+ * org.json.JSONObject runs against a real implementation rather than the
+ * Android SDK stub.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class NfcRepositoryImplTest {
+
+    private fun newRepository(): NfcRepositoryImpl {
+        // The serializer doesn't touch any of these collaborators, so mocks suffice.
+        return NfcRepositoryImpl(
+            context = mock(android.content.Context::class.java),
+            processNfcIntentUseCase = mock(
+                io.github.romantsisyk.nfccardreader.domain.usecase.ProcessNfcIntentUseCase::class.java
+            ),
+            scanDao = mock(
+                io.github.romantsisyk.nfccardreader.data.local.dao.ScanDao::class.java
+            )
+        )
+    }
+
+    private fun callSerialize(repo: NfcRepositoryImpl, map: Map<String, String>): String {
+        val method = NfcRepositoryImpl::class.java.getDeclaredMethod(
+            "serializeTlvMap", Map::class.java
+        )
+        method.isAccessible = true
+        return method.invoke(repo, map) as String
+    }
+
+    @Test
+    fun `serializeTlvMap omits all sensitive tags`() {
+        val repo = newRepository()
+        val map = mapOf(
+            "CARDHOLDER_NAME"        to "JOHN DOE",
+            "EXPIRATION_DATE"        to "250228",
+            "TRACK2_EQUIVALENT_DATA" to "XXXXXXXXXXXX1111D25022010000000000000",
+            "Tag 5F34"               to "01",
+            "Tag 9F1F"               to "DEADBEEF",
+            "Tag 56"                 to "ABCD",
+            "APPLICATION_LABEL"      to "VISA"
+        )
+
+        val json = JSONObject(callSerialize(repo, map))
+
+        // Sensitive entries must be stripped.
+        assertFalse("CARDHOLDER_NAME must not be persisted", json.has("CARDHOLDER_NAME"))
+        assertFalse("EXPIRATION_DATE must not be persisted", json.has("EXPIRATION_DATE"))
+        assertFalse("TRACK2_EQUIVALENT_DATA must not be persisted", json.has("TRACK2_EQUIVALENT_DATA"))
+        assertFalse("PAN sequence (Tag 5F34) must not be persisted", json.has("Tag 5F34"))
+        assertFalse("Track 1 discretionary (Tag 9F1F) must not be persisted", json.has("Tag 9F1F"))
+        assertFalse("Issuer-specific (Tag 56) must not be persisted", json.has("Tag 56"))
+
+        // Non-sensitive entries are preserved.
+        assertTrue("APPLICATION_LABEL should be persisted", json.has("APPLICATION_LABEL"))
+        assertEquals("VISA", json.getString("APPLICATION_LABEL"))
+    }
+
+    @Test
+    fun `serializeTlvMap preserves non-sensitive entries verbatim`() {
+        val repo = newRepository()
+        val map = mapOf(
+            "APPLICATION_IDENTIFIER" to "A0000000031010",
+            "APPLICATION_LABEL"      to "VISA DEBIT",
+            "DEDICATED_FILE_NAME"    to "325041592E5359532E4444463031"
+        )
+
+        val json = JSONObject(callSerialize(repo, map))
+
+        assertEquals("A0000000031010", json.getString("APPLICATION_IDENTIFIER"))
+        assertEquals("VISA DEBIT", json.getString("APPLICATION_LABEL"))
+        assertEquals("325041592E5359532E4444463031", json.getString("DEDICATED_FILE_NAME"))
+        assertEquals(3, json.length())
+    }
+
+    @Test
+    fun `serializeTlvMap returns empty JSON object for empty map`() {
+        val repo = newRepository()
+        val json = JSONObject(callSerialize(repo, emptyMap()))
+        assertEquals(0, json.length())
+        assertNotNull(json)
+    }
+}

--- a/app/src/test/java/io/github/romantsisyk/nfccardreader/domain/EmvTagTest.kt
+++ b/app/src/test/java/io/github/romantsisyk/nfccardreader/domain/EmvTagTest.kt
@@ -2,6 +2,7 @@ package io.github.romantsisyk.nfccardreader.domain
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class EmvTagTest {
@@ -80,72 +81,43 @@ class EmvTagTest {
 
     @Test
     fun `test all tags have non-empty descriptions`() {
-        // Given
-        val allTags = EmvTag.entries
-
-        // When/Then
-        for (tag in allTags) {
+        for (tag in EmvTag.entries) {
             assertNotNull("Tag ${tag.name} should have a description", tag.description)
-            assert(tag.description.isNotEmpty()) { "Tag ${tag.name} has an empty description" }
+            assertTrue("Tag ${tag.name} has an empty description", tag.description.isNotEmpty())
         }
     }
 
     @Test
     fun `test all tags have valid tag values`() {
-        // Given
-        val allTags = EmvTag.entries.filter { it != EmvTag.UNKNOWN }
-
-        // When/Then
-        for (tag in allTags) {
-            // Tag values should be valid hexadecimal strings of 2 or 4 characters
-            assert(tag.tag.matches(Regex("^[0-9A-Fa-f]{2}([0-9A-Fa-f]{2})?$"))) { 
-                "Tag ${tag.name} has an invalid tag value: ${tag.tag}" 
-            }
+        for (tag in EmvTag.entries.filter { it != EmvTag.UNKNOWN }) {
+            assertTrue(
+                "Tag ${tag.name} has an invalid tag value: ${tag.tag}",
+                tag.tag.matches(Regex("^[0-9A-Fa-f]{2}([0-9A-Fa-f]{2})?$"))
+            )
         }
     }
 
     @Test
     fun `test no duplicate tag values`() {
-        // Given
-        val allTags = EmvTag.entries.filter { it != EmvTag.UNKNOWN }
-        val tagValues = mutableSetOf<String>()
+        val seen = mutableSetOf<String>()
         val duplicates = mutableListOf<String>()
-
-        // When
-        for (tag in allTags) {
-            if (!tagValues.add(tag.tag)) {
-                duplicates.add(tag.tag)
-            }
+        for (tag in EmvTag.entries.filter { it != EmvTag.UNKNOWN }) {
+            if (!seen.add(tag.tag)) duplicates.add(tag.tag)
         }
-
-        // Then
-        assert(duplicates.isEmpty()) { "Found duplicate tag values: $duplicates" }
+        assertTrue("Found duplicate tag values: $duplicates", duplicates.isEmpty())
     }
 
     @Test
     fun `test common tags are defined`() {
-        // Given
         val commonTagValues = listOf(
-            "5A",    // PAN
-            "5F20",  // Cardholder Name
-            "5F24",  // Expiration Date
-            "9F02",  // Amount, Authorized
-            "9F03",  // Amount, Other
-            "9F06",  // Application Identifier (AID)
-            "9F26",  // Application Cryptogram
-            "95",    // Terminal Verification Results
-            "9F34",  // Cardholder Verification Method Results
-            "82",    // Application Interchange Profile
-            "9F36",  // Application Transaction Counter
-            "9F37",  // Unpredictable Number
-            "9F10",  // Issuer Application Data
-            "9F1A"   // Terminal Country Code
+            "5A", "5F20", "5F24", "9F02", "9F03", "9F06",
+            "9F26", "95", "9F34", "82", "9F36", "9F37", "9F10", "9F1A"
         )
-
-        // When/Then
         for (tagValue in commonTagValues) {
-            val emvTag = EmvTag.fromTag(tagValue)
-            assert(emvTag != EmvTag.UNKNOWN) { "Common tag $tagValue is not defined in EmvTag enum" }
+            assertTrue(
+                "Common tag $tagValue is not defined in EmvTag enum",
+                EmvTag.fromTag(tagValue) != EmvTag.UNKNOWN
+            )
         }
     }
 

--- a/app/src/test/java/io/github/romantsisyk/nfccardreader/domain/usecase/InterpretNfcDataUseCaseTest.kt
+++ b/app/src/test/java/io/github/romantsisyk/nfccardreader/domain/usecase/InterpretNfcDataUseCaseTest.kt
@@ -1,12 +1,16 @@
 package io.github.romantsisyk.nfccardreader.domain.usecase
 
 import io.github.romantsisyk.nfccardreader.domain.EmvTag
-import io.github.romantsisyk.nfccardreader.util.createByteArrayFromHex
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 
+/**
+ * InterpretNfcDataUseCase consumes the parsed TLV map (Map<String, String>) produced by
+ * ParseTLVUseCase and translates it into the human-readable NFCData domain object.
+ */
 class InterpretNfcDataUseCaseTest {
 
     private lateinit var interpretNfcDataUseCase: InterpretNfcDataUseCase
@@ -17,54 +21,66 @@ class InterpretNfcDataUseCaseTest {
     }
 
     @Test
-    fun `test execute with empty response`() {
-        // Given
-        val emptyResponse = ByteArray(0)
+    fun `execute with empty map returns NFCData with no card type`() {
+        val result = interpretNfcDataUseCase.execute(emptyMap())
 
-        // When
-        val result = interpretNfcDataUseCase.execute(emptyResponse)
-
-        // Then
-        assertEquals("", result.rawResponse)
+        assertNull(result.cardType)
+        assertNull(result.applicationLabel)
+        assertEquals(emptyMap<String, String>(), result.parsedTlvData)
     }
 
     @Test
-    fun `test execute with card type tag`() {
-        // Given
-        val response = createByteArrayFromHex("6F 04 A0 00 00 03")
+    fun `execute resolves Visa AID from APPLICATION_IDENTIFIER_ADDITIONAL`() {
+        val parsed = mapOf(
+            EmvTag.APPLICATION_IDENTIFIER_ADDITIONAL.name to "A0000000031010"
+        )
 
-        // When
-        val result = interpretNfcDataUseCase.execute(response)
+        val result = interpretNfcDataUseCase.execute(parsed)
 
-        // Then
-        assertEquals("6F 04 A0 00 00 03", result.rawResponse)
-        assertEquals("EMV Payment Card", result.cardType)
+        assertEquals("Visa", result.cardType)
     }
 
     @Test
-    fun `test execute with application label tag`() {
-        // Given
-        val response = createByteArrayFromHex("50 04 56 49 53 41") // "VISA" in ASCII
+    fun `execute resolves MasterCard AID from APPLICATION_IDENTIFIER`() {
+        val parsed = mapOf(
+            EmvTag.APPLICATION_IDENTIFIER.name to "A0000000041010"
+        )
 
-        // When
-        val result = interpretNfcDataUseCase.execute(response)
+        val result = interpretNfcDataUseCase.execute(parsed)
 
-        // Then
-        assertEquals("50 04 56 49 53 41", result.rawResponse)
+        assertEquals("MasterCard", result.cardType)
+    }
+
+    @Test
+    fun `execute decodes application label hex into UTF-8 string`() {
+        // "VISA" in ASCII hex = 56 49 53 41
+        val parsed = mapOf(EmvTag.APPLICATION_LABEL.name to "56495341")
+
+        val result = interpretNfcDataUseCase.execute(parsed)
+
         assertEquals("VISA", result.applicationLabel)
     }
 
     @Test
-    fun `test execute with multiple tags`() {
-        // Given
-        val response = createByteArrayFromHex("6F 04 A0 00 00 03 50 04 56 49 53 41")
+    fun `execute decodes currency code EUR`() {
+        // 0x0978 = 978 = EUR
+        val parsed = mapOf(EmvTag.CURRENCY_CODE.name to "0978")
 
-        // When
-        val result = interpretNfcDataUseCase.execute(response)
+        val result = interpretNfcDataUseCase.execute(parsed)
 
-        // Then
-        assertEquals("6F 04 A0 00 00 03 50 04 56 49 53 41", result.rawResponse)
-        assertEquals("EMV Payment Card", result.cardType)
-        assertEquals("VISA", result.applicationLabel)
+        assertEquals("EUR", result.currencyCode)
+    }
+
+    @Test
+    fun `execute preserves parsed TLV data on output`() {
+        val parsed = mapOf(
+            EmvTag.APPLICATION_PAN.name to "XXXXXXXXXXXX1111",
+            EmvTag.EXPIRATION_DATE.name to "250228"
+        )
+
+        val result = interpretNfcDataUseCase.execute(parsed)
+
+        assertEquals(parsed, result.parsedTlvData)
+        assertNotNull(result.parsedTlvData[EmvTag.APPLICATION_PAN.name])
     }
 }

--- a/app/src/test/java/io/github/romantsisyk/nfccardreader/domain/usecase/InterpretNfcDataUseCaseTest.kt
+++ b/app/src/test/java/io/github/romantsisyk/nfccardreader/domain/usecase/InterpretNfcDataUseCaseTest.kt
@@ -48,7 +48,7 @@ class InterpretNfcDataUseCaseTest {
 
         val result = interpretNfcDataUseCase.execute(parsed)
 
-        assertEquals("MasterCard", result.cardType)
+        assertEquals("Mastercard", result.cardType)
     }
 
     @Test

--- a/app/src/test/java/io/github/romantsisyk/nfccardreader/domain/usecase/ParseTLVUseCaseTest.kt
+++ b/app/src/test/java/io/github/romantsisyk/nfccardreader/domain/usecase/ParseTLVUseCaseTest.kt
@@ -16,29 +16,63 @@ class ParseTLVUseCaseTest {
     }
 
     @Test
-    fun `test execute with empty data`() {
-        // Given
-        val emptyData = ByteArray(0)
+    fun `empty input returns empty map`() {
+        assertTrue(parseTLVUseCase.execute(ByteArray(0)).isEmpty())
+    }
 
-        // When
-        val result = parseTLVUseCase.execute(emptyData)
+    @Test
+    fun `PAN tag is masked in result`() {
+        // Tag 5A = APPLICATION_PAN, length 08, 8 bytes of fake PAN
+        val data = createByteArrayFromHex("5A 08 41 11 11 11 11 11 11 11")
+        val result = parseTLVUseCase.execute(data)
 
-        // Then
+        val pan = result["APPLICATION_PAN"]
+        assertTrue("PAN should be present in result", pan != null)
+        assertTrue("PAN should be masked (contain X)", pan!!.contains("X", ignoreCase = true))
+        assertTrue("Masked PAN should not be empty", pan.isNotEmpty())
+    }
+
+    @Test
+    fun `expiration date tag is parsed`() {
+        // Tag 5F24 = EXPIRATION_DATE, length 03, bytes 25 02 28
+        val data = createByteArrayFromHex("5F 24 03 25 02 28")
+        val result = parseTLVUseCase.execute(data)
+
+        val expiry = result["EXPIRATION_DATE"]
+        assertTrue("Expiration date should be present", expiry != null)
+        assertEquals("250228", expiry)
+    }
+
+    @Test
+    fun `multiple tags are all parsed`() {
+        // PAN (5A) + expiry (5F24)
+        val data = createByteArrayFromHex(
+            "5A 08 41 11 11 11 11 11 11 11 " +
+            "5F 24 03 25 02 28"
+        )
+        val result = parseTLVUseCase.execute(data)
+
+        assertEquals(2, result.size)
+        assertTrue(result.containsKey("APPLICATION_PAN"))
+        assertTrue(result.containsKey("EXPIRATION_DATE"))
+    }
+
+    @Test
+    fun `truncated data does not crash`() {
+        // Tag present but length exceeds remaining bytes
+        val data = createByteArrayFromHex("5A 10 41 11")
+        val result = parseTLVUseCase.execute(data)
+        // Should return empty map rather than throw
         assertTrue(result.isEmpty())
     }
 
     @Test
-    fun `test execute with multiple tags`() {
-        // Given
-        val data = createByteArrayFromHex(
-            "5A 08 41 11 11 11 11 11 11 11 " +  // PAN
-            "5F 24 03 25 02 28"                 // Expiration date
-        )
-
-        // When
+    fun `unknown tag is stored with Tag prefix`() {
+        // Tag FF is UNKNOWN, length 02, 2 bytes
+        val data = createByteArrayFromHex("FF 02 AA BB")
         val result = parseTLVUseCase.execute(data)
 
-        // Then
-        assertTrue(result.size >= 1)
+        assertTrue("Unknown tag should be stored with 'Tag' prefix",
+            result.keys.any { it.startsWith("Tag") })
     }
 }

--- a/app/src/test/java/io/github/romantsisyk/nfccardreader/domain/usecase/ParseTLVUseCaseTest.kt
+++ b/app/src/test/java/io/github/romantsisyk/nfccardreader/domain/usecase/ParseTLVUseCaseTest.kt
@@ -68,8 +68,8 @@ class ParseTLVUseCaseTest {
 
     @Test
     fun `unknown tag is stored with Tag prefix`() {
-        // Tag FF is UNKNOWN, length 02, 2 bytes
-        val data = createByteArrayFromHex("FF 02 AA BB")
+        // Tag 01 is single-byte primitive UNKNOWN (not in EmvTag enum)
+        val data = createByteArrayFromHex("01 02 AA BB")
         val result = parseTLVUseCase.execute(data)
 
         assertTrue("Unknown tag should be stored with 'Tag' prefix",

--- a/app/src/test/java/io/github/romantsisyk/nfccardreader/domain/usecase/ParseTLVUseCaseTest.kt
+++ b/app/src/test/java/io/github/romantsisyk/nfccardreader/domain/usecase/ParseTLVUseCaseTest.kt
@@ -75,4 +75,84 @@ class ParseTLVUseCaseTest {
         assertTrue("Unknown tag should be stored with 'Tag' prefix",
             result.keys.any { it.startsWith("Tag") })
     }
+
+    @Test
+    fun `parses real Visa PPSE response and extracts AID`() {
+        // Visa PPSE FCI response. Structure:
+        //   6F (FCI Template)
+        //     84 0E "2PAY.SYS.DDF01"             (DF Name)
+        //     A5 (FCI Proprietary)
+        //       BF 0C (FCI Issuer Discretionary Data)
+        //         61 (Application Template)
+        //           4F 07 A0000000031010          (AID = Visa)
+        //           50 0A "VISA DEBIT"            (Application Label)
+        // Lengths are recomputed for byte-correctness.
+        // Inner 61: 4F(1)+07(1)+7 + 50(1)+0A(1)+10 = 21 -> 0x15
+        // BF0C: 61(1)+15(1)+21 = 23 -> 0x17
+        // A5:   BF(1)+0C(1)+17(1)+23 = 26 -> 0x1A
+        // 6F:   84(1)+0E(1)+14 + A5(1)+1A(1)+26 = 44 -> 0x2C
+        val ppse = "6F2C" +
+            "840E325041592E5359532E4444463031" +     // DF Name
+            "A51A" +
+            "BF0C17" +
+            "6115" +
+            "4F07A0000000031010" +                    // Visa AID
+            "500A56495341204445424954"                 // "VISA DEBIT"
+        val data = createByteArrayFromHex(ppse)
+
+        val result = parseTLVUseCase.execute(data)
+
+        // Constructed templates 6F, A5, BF0C, 61 are recursed; primitives are merged in.
+        // 4F = APPLICATION_IDENTIFIER, stored as hex.
+        assertEquals(
+            "Visa AID should be extracted from PPSE",
+            "A0000000031010",
+            result["APPLICATION_IDENTIFIER"]
+        )
+        // 84 = DEDICATED_FILE_NAME (primitive), stored as hex.
+        assertTrue(
+            "DF Name should be present",
+            result.containsKey("DEDICATED_FILE_NAME")
+        )
+        // 50 = APPLICATION_LABEL (primitive), stored as hex per ParseTLVUseCase else branch.
+        assertEquals(
+            "56495341204445424954",
+            result["APPLICATION_LABEL"]
+        )
+    }
+
+    @Test
+    fun `parses constructed FCI template with 84 and A5 children`() {
+        // 6F (FCI Template) containing:
+        //   84 07 A0000000031010   (DF Name)
+        //   A5 03 50 01 41         (FCI Proprietary -> APPLICATION_LABEL "A")
+        // 6F payload = 84(1)+07(1)+7 + A5(1)+03(1)+3 = 14 -> 0x0E
+        val data = createByteArrayFromHex(
+            "6F0E" +
+                "8407A0000000031010" +
+                "A503500141"
+        )
+
+        val result = parseTLVUseCase.execute(data)
+
+        assertEquals("A0000000031010", result["DEDICATED_FILE_NAME"])
+        assertEquals("41", result["APPLICATION_LABEL"])
+    }
+
+    @Test
+    fun `handles long-form length 0x81 with length byte greater than 127`() {
+        // Primitive tag 9F10 (ISSUER_APPLICATION_DATA) with long-form length 0x81 0x80
+        // -> 128 bytes of value. Verifies the parser correctly reads multi-byte tag,
+        // honours long-form length, and consumes the full 128-byte value.
+        val valueHex = "AB".repeat(128)
+        val data = createByteArrayFromHex("9F10" + "8180" + valueHex)
+
+        val result = parseTLVUseCase.execute(data)
+
+        assertEquals(
+            "Long-form length 0x81 0x80 must read full 128-byte value",
+            valueHex,
+            result["ISSUER_APPLICATION_DATA"]
+        )
+    }
 }

--- a/app/src/test/java/io/github/romantsisyk/nfccardreader/presentation/viewmodel/NFCReaderViewModelTest.kt
+++ b/app/src/test/java/io/github/romantsisyk/nfccardreader/presentation/viewmodel/NFCReaderViewModelTest.kt
@@ -3,13 +3,14 @@ package io.github.romantsisyk.nfccardreader.presentation.viewmodel
 import android.content.Intent
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import io.github.romantsisyk.nfccardreader.domain.model.NFCData
+import io.github.romantsisyk.nfccardreader.domain.model.NfcError
 import io.github.romantsisyk.nfccardreader.domain.model.NfcResult
 import io.github.romantsisyk.nfccardreader.domain.repository.NfcAvailability
 import io.github.romantsisyk.nfccardreader.domain.repository.NfcRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -20,10 +21,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
-/**
- * Unit tests for NFCReaderViewModel.
- * Tests state management and repository interactions.
- */
 @ExperimentalCoroutinesApi
 class NFCReaderViewModelTest {
 
@@ -47,109 +44,156 @@ class NFCReaderViewModelTest {
     }
 
     @Test
-    fun `test initial state`() = runTest {
+    fun `initial state has empty data and no error`() = runTest {
         testDispatcher.scheduler.advanceUntilIdle()
-
-        // Initial state should have empty data
-        val uiState = viewModel.uiState.value
-        assertTrue(uiState.nfcTagData.isEmpty())
-        assertEquals("Empty NFC Response", uiState.rawResponse)
-        assertNull(uiState.additionalInfo)
-        assertNull(uiState.errorMessage)
+        val state = viewModel.uiState.value
+        assertTrue(state.nfcTagData.isEmpty())
+        assertNull(state.additionalInfo)
+        assertNull(state.errorMessage)
+        assertFalse(state.isLoading)
     }
 
     @Test
-    fun `test clearNfcData`() = runTest {
-        // First load some mock data
-        viewModel.processMockNfcIntent()
+    fun `NFC availability is checked on init`() = runTest {
+        testDispatcher.scheduler.advanceUntilIdle()
+        val availability = viewModel.uiState.value.nfcAvailability
+        assertNotNull(availability)
+        assertTrue(availability!!.isAvailable)
+        assertTrue(availability.isEnabled)
+    }
+
+    @Test
+    fun `processNfcIntent success updates state with card data`() = runTest {
+        val fakeIntent = Intent()
+        viewModel.processNfcIntent(fakeIntent)
         testDispatcher.scheduler.advanceUntilIdle()
 
-        // Then clear it
+        val state = viewModel.uiState.value
+        assertFalse(state.isLoading)
+        assertNull(state.errorMessage)
+        assertNotNull(state.additionalInfo)
+        assertEquals("Test Card", state.additionalInfo?.cardType)
+        assertEquals(mapOf("Test" to "Data"), state.nfcTagData)
+    }
+
+    @Test
+    fun `processNfcIntent error updates errorMessage`() = runTest {
+        fakeRepository.shouldFailNextIntent = true
+        viewModel.processNfcIntent(Intent())
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isLoading)
+        assertNotNull(state.errorMessage)
+        assertEquals(NfcError.COMMUNICATION_ERROR, state.error)
+    }
+
+    @Test
+    fun `clearNfcData resets state but preserves nfcAvailability`() = runTest {
+        viewModel.processNfcIntent(Intent())
+        testDispatcher.scheduler.advanceUntilIdle()
+
         viewModel.clearNfcData()
-
-        // Check if data was cleared
-        val uiState = viewModel.uiState.value
-        assertTrue(uiState.nfcTagData.isEmpty())
-        assertEquals("Empty NFC Response", uiState.rawResponse)
-        assertNull(uiState.additionalInfo)
-        assertNull(uiState.errorMessage)
+        val state = viewModel.uiState.value
+        assertTrue(state.nfcTagData.isEmpty())
+        assertNull(state.additionalInfo)
+        assertNull(state.errorMessage)
+        assertNotNull(state.nfcAvailability)
     }
 
     @Test
-    fun `test processMockNfcIntent`() = runTest {
-        // When
-        viewModel.processMockNfcIntent()
+    fun `saveCurrentScan with no data is no-op`() = runTest {
+        viewModel.saveCurrentScan()
         testDispatcher.scheduler.advanceUntilIdle()
-
-        // Then - verify the mock data contains expected fields
-        val uiState = viewModel.uiState.value
-        assertFalse(uiState.nfcTagData.isEmpty())
-        assertNotEquals("Empty NFC Response", uiState.rawResponse)
-
-        val mockData = uiState.additionalInfo
-        assertNotNull(mockData)
-        assertEquals("MasterCard Credit", mockData?.cardType)
-        assertEquals("MasterCard", mockData?.applicationLabel)
-        assertEquals("25.00", mockData?.transactionAmount)
-        assertEquals("USD", mockData?.currencyCode)
+        assertFalse(viewModel.uiState.value.lastScanSaved)
     }
 
     @Test
-    fun `test nfc availability check`() = runTest {
+    fun `saveCurrentScan with data sets lastScanSaved to true`() = runTest {
+        viewModel.processNfcIntent(Intent())
         testDispatcher.scheduler.advanceUntilIdle()
 
-        val uiState = viewModel.uiState.value
-        assertNotNull(uiState.nfcAvailability)
-        assertTrue(uiState.nfcAvailability?.isAvailable == true)
-        assertTrue(uiState.nfcAvailability?.isEnabled == true)
+        viewModel.saveCurrentScan()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.lastScanSaved)
+    }
+
+    @Test
+    fun `deleteScan error updates errorMessage`() = runTest {
+        fakeRepository.shouldFailDelete = true
+        viewModel.deleteScan(1L)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertNotNull(viewModel.uiState.value.errorMessage)
+    }
+
+    @Test
+    fun `clearHistory error updates errorMessage`() = runTest {
+        fakeRepository.shouldFailClear = true
+        viewModel.clearHistory()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertNotNull(viewModel.uiState.value.errorMessage)
+    }
+
+    @Test
+    fun `dismissError clears error state`() = runTest {
+        fakeRepository.shouldFailNextIntent = true
+        viewModel.processNfcIntent(Intent())
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertNotNull(viewModel.uiState.value.errorMessage)
+
+        viewModel.dismissError()
+        assertNull(viewModel.uiState.value.errorMessage)
+        assertNull(viewModel.uiState.value.error)
     }
 }
 
-/**
- * Fake repository implementation for testing.
- */
 private class FakeNfcRepository : NfcRepository {
 
-    private val scanHistory = mutableListOf<NFCData>()
+    var shouldFailNextIntent = false
+    var shouldFailDelete = false
+    var shouldFailClear = false
+
+    private val _history = MutableStateFlow<List<NFCData>>(emptyList())
 
     override suspend fun processNfcIntent(intent: Intent): NfcResult<NFCData> {
-        return NfcResult.Success(
-            NFCData(
-                rawResponse = "TEST",
-                cardType = "Test Card",
-                parsedTlvData = mapOf("Test" to "Data")
-            )
-        )
-    }
-
-    override suspend fun saveScanRecord(nfcData: NFCData): NfcResult<Long> {
-        scanHistory.add(nfcData)
-        return NfcResult.Success(scanHistory.size.toLong())
-    }
-
-    override fun getScanHistory(): Flow<List<NFCData>> {
-        return flowOf(scanHistory.toList())
-    }
-
-    override suspend fun getScanById(id: Long): NfcResult<NFCData> {
-        val scan = scanHistory.getOrNull(id.toInt() - 1)
-        return if (scan != null) {
-            NfcResult.Success(scan)
+        return if (shouldFailNextIntent) {
+            shouldFailNextIntent = false
+            NfcResult.Error(NfcError.COMMUNICATION_ERROR, "Simulated error")
         } else {
-            NfcResult.Error(
-                io.github.romantsisyk.nfccardreader.domain.model.NfcError.INVALID_DATA,
-                "Not found"
+            NfcResult.Success(
+                NFCData(rawResponse = "TEST", cardType = "Test Card", parsedTlvData = mapOf("Test" to "Data"))
             )
         }
     }
 
+    override suspend fun saveScanRecord(nfcData: NFCData): NfcResult<Long> {
+        _history.value = _history.value + nfcData
+        return NfcResult.Success(_history.value.size.toLong())
+    }
+
+    override fun getScanHistory(): Flow<List<NFCData>> = _history
+
+    override suspend fun getScanById(id: Long): NfcResult<NFCData> {
+        val scan = _history.value.getOrNull(id.toInt() - 1)
+        return if (scan != null) NfcResult.Success(scan)
+        else NfcResult.Error(NfcError.INVALID_DATA, "Not found")
+    }
+
     override suspend fun deleteScan(id: Long): NfcResult<Unit> {
-        return NfcResult.Success(Unit)
+        return if (shouldFailDelete) NfcResult.Error(NfcError.UNKNOWN_ERROR, "Delete failed")
+        else NfcResult.Success(Unit)
     }
 
     override suspend fun clearHistory(): NfcResult<Unit> {
-        scanHistory.clear()
-        return NfcResult.Success(Unit)
+        return if (shouldFailClear) {
+            NfcResult.Error(NfcError.UNKNOWN_ERROR, "Clear failed")
+        } else {
+            _history.value = emptyList()
+            NfcResult.Success(Unit)
+        }
     }
 
     override fun checkNfcAvailability(): NfcResult<NfcAvailability> {

--- a/app/src/test/java/io/github/romantsisyk/nfccardreader/utils/NfcDataDecoderTest.kt
+++ b/app/src/test/java/io/github/romantsisyk/nfccardreader/utils/NfcDataDecoderTest.kt
@@ -179,13 +179,13 @@ class NfcDataDecoderTest {
     @Test
     fun `test decodeApplicationIdentifier with MasterCard AID`() {
         // Given
-        val bytes = createHexList("A0 00 00 00 04 10 10") // MasterCard
-        
+        val bytes = createHexList("A0 00 00 00 04 10 10") // Mastercard
+
         // When
         val result = NfcDataDecoder.decodeApplicationIdentifier(bytes)
-        
+
         // Then
-        assertEquals("MasterCard", result)
+        assertEquals("Mastercard", result)
     }
 
     @Test

--- a/app/src/test/java/io/github/romantsisyk/nfccardreader/utils/NfcDataDecoderTest.kt
+++ b/app/src/test/java/io/github/romantsisyk/nfccardreader/utils/NfcDataDecoderTest.kt
@@ -290,13 +290,46 @@ class NfcDataDecoderTest {
 
     @Test
     fun `test decodeFormFactorIndicator with unknown form factor`() {
-        // Given
-        val bytes = createHexList("99 00 00 00") // Unknown
-        
-        // When
-        val result = NfcDataDecoder.decodeFormFactorIndicator(bytes)
-        
-        // Then
-        assertEquals("Unknown form factor", result)
+        val bytes = createHexList("99 00 00 00")
+        assertEquals("Unknown form factor", NfcDataDecoder.decodeFormFactorIndicator(bytes))
+    }
+
+    // Edge case: bounds checks
+    @Test
+    fun `decodeDate with fewer than 3 bytes returns Invalid Date`() {
+        assertEquals("Invalid Date", NfcDataDecoder.decodeDate(listOf("23", "04")))
+        assertEquals("Invalid Date", NfcDataDecoder.decodeDate(listOf("23")))
+        assertEquals("Invalid Date", NfcDataDecoder.decodeDate(emptyList()))
+    }
+
+    @Test
+    fun `decodeTime with fewer than 3 bytes returns Invalid Time`() {
+        assertEquals("Invalid Time", NfcDataDecoder.decodeTime(listOf("10", "35")))
+        assertEquals("Invalid Time", NfcDataDecoder.decodeTime(emptyList()))
+    }
+
+    @Test
+    fun `decodeAmount with empty list returns 0 00`() {
+        assertEquals("0.00", NfcDataDecoder.decodeAmount(emptyList()))
+    }
+
+    @Test
+    fun `decodeServiceCode with fewer than 3 bytes returns Incomplete Service Code`() {
+        assertEquals("Incomplete Service Code", NfcDataDecoder.decodeServiceCode(listOf("1", "0")))
+        assertEquals("Incomplete Service Code", NfcDataDecoder.decodeServiceCode(emptyList()))
+    }
+
+    @Test
+    fun `decodeCountryCode with unknown code returns Unknown Country`() {
+        val bytes = createHexList("99 99")
+        assertTrue(NfcDataDecoder.decodeCountryCode(bytes).startsWith("Unknown Country"))
+    }
+
+    @Test
+    fun `decodeCountryCode for USA returns non-empty result`() {
+        // 840 = USA in ISO 3166-1
+        val bytes = createHexList("03 48")
+        val result = NfcDataDecoder.decodeCountryCode(bytes)
+        assertTrue("Should return a non-empty country name or Unknown", result.isNotEmpty())
     }
 }

--- a/app/src/test/java/io/github/romantsisyk/nfccardreader/utils/NfcDataMaskerTest.kt
+++ b/app/src/test/java/io/github/romantsisyk/nfccardreader/utils/NfcDataMaskerTest.kt
@@ -86,11 +86,34 @@ class NfcDataMaskerTest {
     fun `test maskTrack2Data with empty string`() {
         // Given
         val track2 = ""
-        
+
         // When
         val result = NfcDataMasker.maskTrack2Data(track2)
-        
+
         // Then
         assertEquals("", result)
+    }
+
+    @Test
+    fun `maskPan strips BCD pad nibble for 15-digit Amex PAN`() {
+        // 15-digit Amex PAN encoded in EMV BCD with trailing F nibble pad.
+        val amexBcd = "378282246310005F"
+
+        val result = NfcDataMasker.maskPan(amexBcd)
+
+        // Padding nibble must be removed before masking, and exactly the last
+        // 4 digits of the real PAN must remain visible.
+        assertEquals("XXXXXXXXXXX0005", result)
+        assertEquals(15, result.length)
+        assertTrue("Must not leak any of the leading PAN digits", !result.contains("3782"))
+    }
+
+    @Test
+    fun `maskPan with trailing lowercase f pad is also stripped`() {
+        val amexBcd = "378282246310005f"
+
+        val result = NfcDataMasker.maskPan(amexBcd)
+
+        assertEquals("XXXXXXXXXXX0005", result)
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,27 +1,10 @@
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath("com.google.dagger:hilt-android-gradle-plugin:2.51.1")
-    }
-}
-
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.jetbrains.kotlin.android) apply false
-    id("com.google.devtools.ksp") version "1.9.0-1.0.13" apply false
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-        maven { url = uri("https://jitpack.io") }
-    }
+    alias(libs.plugins.hilt.android) apply false
+    alias(libs.plugins.ksp) apply false
 }
 
 tasks.register("clean", Delete::class) {
-    delete(rootProject.buildDir)
+    delete(rootProject.layout.buildDirectory)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 # Project-wide Gradle settings
 android.useAndroidX=true
-android.enableJetifier=true
+android.enableJetifier=false
 android.suppressUnsupportedCompileSdk=35
 
 # JVM & ByteBuddy settings
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 -Dnet.bytebuddy.experimental=true
+org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m -Dfile.encoding=UTF-8 -Dnet.bytebuddy.experimental=true
 org.gradle.daemon=true
 
 # Configuration cache

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,51 +1,48 @@
 [versions]
-agp = "8.5.2"
-hiltAndroid = "2.52"
-hiltCompiler = "2.51.1"
+agp = "8.7.3"
+hilt = "2.52"
 hiltCompilerVersion = "1.2.0"
-hiltLifecycleViewmodel = "1.0.0-alpha03"
-kotlin = "1.9.0"
+kotlin = "1.9.24"
+ksp = "1.9.24-1.0.20"
 coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.9.3"
-composeBom = "2024.04.01"
+composeBom = "2024.11.00"
 materialIconsExtended = "1.7.8"
 mockitoCore = "4.5.1"
 mockitoInline = "4.5.1"
 mockitoKotlin = "4.1.0"
-coroutinesTest = "1.6.4"
-androidXTestCore = "1.5.0"
-androidXTestRunner = "1.5.0"
+coroutinesTest = "1.8.1"
+androidXTestCore = "1.6.1"
+androidXTestRunner = "1.6.1"
 archCoreTesting = "2.2.0"
-robolectric = "4.9"
-truth = "1.1.3"
-junitJupiter = "5.9.3"
-androidXTestRules = "1.5.0"
+robolectric = "4.13"
+androidXTestRules = "1.6.1"
 room = "2.6.1"
-navigationCompose = "2.7.7"
+navigationCompose = "2.8.4"
 hiltNavigationCompose = "1.2.0"
 
 [libraries]
-androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version = "1.15.0" }
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "hiltCompilerVersion" }
-androidx-hilt-lifecycle-viewmodel = { module = "androidx.hilt:hilt-lifecycle-viewmodel", version.ref = "hiltLifecycleViewmodel" }
 androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "materialIconsExtended" }
-hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hiltAndroid" }
-hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hiltCompiler" }
+hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
+hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
+hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hilt" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
-androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version = "1.9.3" }
-androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version = "2024.11.00" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
-androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest", version = "1.7.5" }
+androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 
@@ -58,18 +55,12 @@ androidx-test-core = { group = "androidx.test", name = "core", version.ref = "an
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidXTestRunner" }
 androidx-arch-core-testing = { group = "androidx.arch.core", name = "core-testing", version.ref = "archCoreTesting" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
-truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
-junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junitJupiter" }
-junit-jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junitJupiter" }
-junit-jupiter-params = { group = "org.junit.jupiter", name = "junit-jupiter-params", version.ref = "junitJupiter" }
 androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "androidXTestRules" }
-hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hiltAndroid" }
 
 # Room
 room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
-room-testing = { group = "androidx.room", name = "room-testing", version.ref = "room" }
 
 # Navigation
 navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
@@ -78,3 +69,5 @@ hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-com
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Nov 22 23:11:40 CET 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,7 +6,7 @@ pluginManagement {
     }
 }
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.PREFER_PROJECT)
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
…ening

Breaking changes:
- Room database migrated to v2 (schema extended with scan history)
- NfcRepository now returns NfcResult<T> sealed type instead of raw data

What's new:
- Full BER-TLV parser: multi-byte tags, long-form lengths, constructed template recursion
- PPSE-based AID discovery with fallback to Visa/Mastercard/Amex/JCB/UnionPay/Discover
- Scan history stored in Room with full CRUD (list, detail, delete, clear)
- History screen with per-scan detail navigation
- SW1/SW2 APDU status word verification on every card command

Security (PCI-DSS):
- PAN, Track 2, cardholder name, expiry never written to database
- FLAG_SECURE prevents screenshots of card data
- Raw APDU hex removed from UI
- All Log calls stripped in release via ProGuard -assumenosideeffects

Bug fixes:
- PAN masking now handles BCD-padded 15-digit Amex PANs correctly
- Country code decoder treats EMV bytes as BCD, not hexadecimal
- Currency fallback uses ISO 4217 decimal numeric code lookup
- Date/time decoders validate BCD pairs before formatting
- Intent re-processing on resume fixed (consumed after first handle)
- Foreground NFC dispatch correctly enabled/disabled in onResume/onPause

Build:
- Kotlin 1.9.24 / KSP 1.9.24-1.0.20 / Compose Compiler 1.5.14 / BOM 2024.11.00
- Migrated from KAPT to KSP for Hilt and Room
- Jetifier disabled, JVM heap raised to 4096m
- ProGuard: Room _Impl, DAO, TypeConverter, Migration keep rules added

CI/CD:
- Concurrency group cancels stale PR runs
- JUnit XML uploaded for inline GitHub test annotations
- Release APK signature verified with apksigner
- Keystore decode hardened with umask 077